### PR TITLE
re-factor and fix Time component for input > 60 hours

### DIFF
--- a/src/components/Time.js
+++ b/src/components/Time.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const thousandsValues = [1000, 59999, 60000, 3, 3600000];
-const hundredsValues = [100, 5999, 6000, 2, 360000];
+import {
+  parseTimeHundreds,
+  parseTimeThousands,
+  parsedTimeToString,
+} from '../utils/recTime';
 
 class Time extends React.Component {
   static propTypes = {
@@ -35,28 +37,11 @@ class Time extends React.Component {
       return `${apples} apple${apples !== 1 ? `s` : ``}`;
     }
 
-    let values = hundredsValues;
     if (thousands) {
-      values = thousandsValues;
+      return parsedTimeToString(parseTimeThousands(time), true);
+    } else {
+      return parsedTimeToString(parseTimeHundreds(time), false);
     }
-    const string = `${Math.floor((time / values[0]) % 60)
-      .toString()
-      .padStart(time > 999 ? 2 : 1, 0)},${(time % values[0])
-      .toString()
-      .padStart(values[3], 0)}`;
-
-    if (time > values[4]) {
-      const hours = Math.floor((time / values[4]) % 60);
-      return `${hours}:${Math.floor(time / values[2] - hours * 60)
-        .toString()
-        .padStart(2, 0)}:${string}`;
-    }
-
-    if (time > values[1]) {
-      return `${Math.floor(time / values[2])}:${string}`;
-    }
-
-    return string;
   };
 
   render() {

--- a/src/utils/recTime.js
+++ b/src/utils/recTime.js
@@ -1,0 +1,92 @@
+/**
+ * * ie. ( 3885, [ 3600, 60, 1 ] ) => [1, 4, 45]
+ *
+ * This tells us that 3885 seconds is 1 hour, 4 minutes, and 45 seconds.
+ *
+ * Passing in different breakpoints allows time to be in hundreds or thousands of
+ * a second. @see parseTimeHundreds, and parseTimeThousands.
+ *
+ * @param time int
+ * @param breakpoints array
+ * @returns {[]}
+ */
+const parseTime = (time, breakpoints = [3600, 60, 1]) => {
+  let ret = [];
+  let remaining = time;
+  breakpoints.forEach((b, index) => {
+    let hours_min_sec_etc = Math.floor(remaining / b);
+    remaining = remaining - hours_min_sec_etc * b;
+    ret.push(hours_min_sec_etc);
+  });
+  return ret;
+};
+
+export const parseTimeHundreds = time => {
+  return parseTime(time, [360000, 6000, 100, 1]);
+};
+
+export const parseTimeThousands = time => {
+  return parseTime(time, [3600000, 60000, 1000, 1]);
+};
+
+/**
+ * [0,3,26,65], false => "3:26,65"
+ * [0,0,10,65], true => "10,065"
+ *
+ * @param parsed - array of 4 integers: hours, minutes, seconds, ms or hundreds of a second
+ * @param thousands = true if parsed[3] represents mili-seconds (not hundreds of a second)
+ * @returns {string}
+ */
+export const parsedTimeToString = (parsed, thousands = false) => {
+  // ie. [ 0, 0, 5, 25] => [ "00", "00", "05", "25" ] (5.25 seconds)
+  const parts = parsed.map((int, index) => {
+    let len = 2;
+
+    if (thousands && index === parsed.length - 1) {
+      len = 3;
+    }
+
+    return int.toString().padStart(len, '0');
+  });
+
+  // ie. "00:00:05,25"
+  const str = parts
+    .slice(0, -1)
+    .join(':')
+    .concat(',', parts[parts.length - 1]);
+
+  let foundNonZeroOrColon = false;
+
+  // remove "0"'s and ":"'s from beginning of string
+  // "00:02:15,13" => "2:15,13"
+  // "00:00:00,00" => ",00" (we'll fix this after)
+  let _str = Array.from(str)
+    .filter(char => {
+      if (foundNonZeroOrColon) {
+        return true;
+      }
+
+      if (['0', ':'].includes(char)) {
+        return false;
+      } else {
+        // char is an integer or a comma.
+        // since we always catch the comma before the last
+        // 2 integers, its worth noting that the last 2 ints
+        // never get filtered out even if they are zeroes.
+        foundNonZeroOrColon = true;
+        return true;
+      }
+    })
+    .join('');
+
+  // ",75" => "0,75" or ",00" => "0,00"
+  if (_str.startsWith(',')) {
+    _str = '0' + _str;
+  } else if (_str.charAt(1) === ',') {
+    // "1,55" => "01,55" ?
+    // used to work like this for miliseconds only.
+    // _str = "0" + _str;
+  }
+
+  return _str;
+};

--- a/src/utils/recTime.js
+++ b/src/utils/recTime.js
@@ -83,9 +83,8 @@ export const parsedTimeToString = (parsed, thousands = false) => {
   if (_str.startsWith(',')) {
     _str = '0' + _str;
   } else if (_str.charAt(1) === ',') {
-    // "1,55" => "01,55" ?
-    // used to work like this for miliseconds only.
-    // _str = "0" + _str;
+    // "1,55" => "01,55"
+    _str = '0' + _str;
   }
 
   return _str;


### PR DESCRIPTION
everything should be identical on the front-end except that times like 8.5 seconds (when displayed using mili seconds) will show up as 8,500 and not 08,500 as it used to be. Times in hundreds used to show up as 8,50, and will continue to show up like this. The fix was to address the total time (and time played for death, esc, etc.) on the personal stats page, which when it was greater than 60 hours or so, did not display correctly. It would show something like 4:3423:34,50 which would mean 4 hours, 3423 minutes, 34 seconds, etc. Should now be fixed.