### PR TITLE
feat(recPlayer): zoom out on mobile, adjust height on battle page, ad…

### DIFF
--- a/src/components/Recplayer.js
+++ b/src/components/Recplayer.js
@@ -1,11 +1,28 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 
 const RecPlayer =
   typeof document !== 'undefined' && require('recplayer-react').default; // eslint-disable-line global-require
 
 const Recplayer = props => {
-  const { rec, lev, width, height, zoom, controls, imageUrl, autoPlay } = props;
+  const { rec, lev, width, height, controls, imageUrl, autoPlay } = props;
+
+  let defaultZoom = 1;
+
+  if (useMediaQuery('(max-width: 900px)')) {
+    defaultZoom = 0.9;
+  }
+
+  if (useMediaQuery('(max-width: 640px)')) {
+    defaultZoom = 0.75;
+  }
+
+  if (useMediaQuery('(max-width: 500px)')) {
+    defaultZoom = 0.7;
+  }
+
+  const zoom = props.zoom || defaultZoom;
 
   let shouldAutoPlay = false;
 
@@ -56,7 +73,7 @@ Recplayer.defaultProps = {
   rec: null,
   width: 'auto',
   height: 'auto',
-  zoom: 1,
+  zoom: undefined,
   controls: true,
   imageUrl: 'https://api.elma.online/recplayer',
   autoPlay: 'if-visible',

--- a/src/pages/battle/RecView.js
+++ b/src/pages/battle/RecView.js
@@ -65,10 +65,16 @@ const PlayerContainer = styled.div`
   box-sizing: border-box;
   .player {
     background: #f1f1f1;
-    height: 400px;
+    height: 550px;
     display: flex;
     align-items: center;
     justify-content: center;
+    @media screen and (max-width: 1650px) {
+      height: 450px;
+    }
+    @media screen and (max-width: 500px) {
+      height: 400px;
+    }
   }
   @media screen and (max-width: 1100px) {
     float: none;

--- a/src/pages/battle/index.js
+++ b/src/pages/battle/index.js
@@ -4,6 +4,9 @@ import PropTypes from 'prop-types';
 import { groupBy, mapValues, sumBy, filter } from 'lodash';
 import Layout from 'components/Layout';
 import styled from 'styled-components';
+import Time from '../../components/Time';
+import Kuski from '../../components/Kuski.js';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
 import { battleStatus } from 'utils/battle';
 import RecView from './RecView';
 import RightBarContainer from './RightBarContainer';
@@ -39,6 +42,20 @@ const runData = runs => {
   return runStats;
 };
 
+const getWinnerData = battle => {
+  if (battle && battle.Results && battle.Results.length > 0) {
+    const r = battle.Results[0];
+
+    return {
+      Kuski: r.KuskiData || {},
+      Time: r.Time,
+      Apples: r.Apples,
+    };
+  }
+
+  return null;
+};
+
 const Battle = ({ BattleId }) => {
   const BattleIndex = parseInt(BattleId, 10);
   let runStats = null;
@@ -67,6 +84,10 @@ const Battle = ({ BattleId }) => {
 
   const isWindow = typeof window !== 'undefined';
 
+  const winner = getWinnerData(battle);
+
+  const showWinnerTitle = useMediaQuery('(max-width: 1000px)');
+
   return (
     <Layout
       t={`Battle - ${
@@ -74,6 +95,13 @@ const Battle = ({ BattleId }) => {
       }`}
     >
       <MainContainer>
+        {battle && winner && showWinnerTitle && (
+          <WinnerTitle>
+            <Kuski kuskiData={winner.Kuski} flag={true} team={false} />
+            <span>&nbsp;</span>
+            <Time time={winner.Time} apples={winner.Apples} />
+          </WinnerTitle>
+        )}
         {battle ? (
           <RecView
             isWindow={isWindow}
@@ -120,6 +148,11 @@ Battle.defaultProps = {
 const MainContainer = styled.div`
   display: inline-block;
   width: 100%;
+`;
+
+const WinnerTitle = styled.div`
+  padding-left: 7px;
+  margin-bottom: 2px;
 `;
 
 export default Battle;


### PR DESCRIPTION
…d winner title on mobile battle page.

Default zoom on mobile is about 0.7 and goes up towards 1 on desktop. This affects ALL rec player instances, for which there are many (cups page, replays, levels, battles, and many more). In the future I'd like to add zoom controls for mobile but that's will take much longer to implement. For now this should make replays much more enjoyable to watch on a phone.

Rec player on battle page is a bit taller on wide screens (used to be very wide and short). Remains same height on phones.

When battle page collapses to 1 column, I added the player/country and time just above the rec player. This is useful on phones so you know who is driving without scrolling down the page. Sometimes it can be very far to scroll.. with long winner history and some chat history. Decided not to show it on desktop because its normally very easy to see who winner is, but wouldn't hurt either way IMO.