### PR TITLE
feat(cup): added routing to tabs

### DIFF
--- a/src/components/CupCurrent.js
+++ b/src/components/CupCurrent.js
@@ -6,11 +6,12 @@ import Kuski from 'components/Kuski';
 import Download from 'components/Download';
 import { Paper } from 'components/Paper';
 import { Timer } from '@material-ui/icons';
+import Link from 'components/Link';
 
 const eventSort = (a, b) => a.CupIndex - b.CupIndex;
 
 const CupResults = props => {
-  const { events } = props;
+  const { events, ShortName } = props;
 
   const currentEvents = events.filter(
     e =>
@@ -28,37 +29,36 @@ const CupResults = props => {
   return (
     <Container>
       {currentEvents.map(c => (
-        <Fragment key={`${c.CupIndex}${c.StartTime}`}>
-          {c.EndTime > format(new Date(), 't') &&
-            c.StartTime < format(new Date(), 't') && (
-              <Paper>
-                <EventHeader>
-                  Event {getEventNumber(c)} by <Kuski kuskiData={c.KuskiData} />
-                </EventHeader>
-                <EventInfo>
-                  {c.Level && (
-                    <Download href={`level/${c.LevelIndex}`}>
-                      {c.Level.LevelName}
-                    </Download>
-                  )}
-                </EventInfo>
-                <EventInfo>
-                  Deadline:{' '}
-                  <LocalTime
-                    date={c.EndTime}
-                    format="ddd D MMM YYYY HH:mm"
-                    parse="X"
-                  />
-                </EventInfo>
-                <EventInfo>
-                  <Timer />{' '}
-                  {formatDistance(new Date(c.EndTime * 1000), new Date(), {
-                    addSuffix: true,
-                  })}
-                </EventInfo>
-              </Paper>
+        <Paper>
+          <EventHeader>
+            <Link to={`/cup/${ShortName}/events/${getEventNumber(c)}/map`}>
+              Event {getEventNumber(c)}
+            </Link>
+            <span> by </span>
+            <Kuski kuskiData={c.KuskiData} />
+          </EventHeader>
+          <EventInfo>
+            {c.Level && (
+              <Download href={`level/${c.LevelIndex}`}>
+                {c.Level.LevelName}
+              </Download>
             )}
-        </Fragment>
+          </EventInfo>
+          <EventInfo>
+            Deadline:{' '}
+            <LocalTime
+              date={c.EndTime}
+              format="ddd D MMM YYYY HH:mm"
+              parse="X"
+            />
+          </EventInfo>
+          <EventInfo>
+            <Timer />{' '}
+            {formatDistance(new Date(c.EndTime * 1000), new Date(), {
+              addSuffix: true,
+            })}
+          </EventInfo>
+        </Paper>
       ))}
     </Container>
   );

--- a/src/components/CupWidget.js
+++ b/src/components/CupWidget.js
@@ -23,7 +23,7 @@ const CupWidget = ({ ShortName }) => {
           <Header onClick={() => navigate(`/cup/${ShortName}`)} h2>
             {cup.CupName}
           </Header>
-          <CupCurrent events={events} />
+          <CupCurrent events={events} ShortName={ShortName} />
           <Text onClick={() => navigate(`/cup/${ShortName}`)}>
             Open cup page to upload replays
           </Text>

--- a/src/pages/cup/Dashboard.js
+++ b/src/pages/cup/Dashboard.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { forEach } from 'lodash';
 import { format } from 'date-fns';
+import Link from 'components/Link';
 import styled from 'styled-components';
 import { Grid, Checkbox, Button, TextField } from '@material-ui/core';
 import Header from 'components/Header';
@@ -17,7 +18,7 @@ import config from 'config';
 import { authToken } from 'utils/nick';
 
 const Dashboard = props => {
-  const { events, openEvent, openStandings, cup } = props;
+  const { events, cup } = props;
   const [standings, setStandings] = useState({});
   const [lastEvent, setLastEvent] = useState(-1);
   const [error, setError] = useState('');
@@ -158,8 +159,10 @@ const Dashboard = props => {
           <CupCurrent events={events} />
         </Grid>
         <Grid item xs={12} sm={6}>
-          <Header h2 onClick={() => openEvent(lastEvent)}>
-            Last Event
+          <Header h2>
+            <Link to={`/cup/${cup.ShortName}/events/${lastEvent + 1}`}>
+              Last Event
+            </Link>
           </Header>
           {events[lastEvent] && (
             <CupResults
@@ -169,8 +172,8 @@ const Dashboard = props => {
               results={events[lastEvent].CupTimes.slice(0, 5)}
             />
           )}
-          <Header h2 onClick={() => openStandings()}>
-            Standings
+          <Header h2>
+            <Link to={`/cup/${cup.ShortName}/standings`}>Standings</Link>
           </Header>
           {standings.player && (
             <DerpTable

--- a/src/pages/cup/Events.js
+++ b/src/pages/cup/Events.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import { useNavigate } from '@reach/router';
 import { formatDistance, format } from 'date-fns';
 import LocalTime from 'components/LocalTime';
 import Time from 'components/Time';
@@ -28,16 +29,18 @@ const GetWinner = times => {
 };
 
 const Cups = props => {
-  const { events, setEvent, cup } = props;
-  const [openEvent, setOpenEvent] = useState(-1);
-  const [tab, setTab] = useState(0);
-
-  useEffect(() => {
-    setOpenEvent(setEvent);
-  }, [setEvent]);
+  const { cup, events, eventNumber, eventTab } = props;
+  const eventIndex = eventNumber - 1;
+  const navigate = useNavigate();
 
   if (!events) {
-    return null;
+    return <div>No events found.</div>;
+  }
+
+  const event = events[eventIndex];
+
+  if (event === undefined) {
+    return <div>Event does not exist.</div>;
   }
 
   return (
@@ -46,8 +49,15 @@ const Cups = props => {
         {events.sort(eventSort).map((e, i) => (
           <EventContainer
             key={e.CupIndex}
-            highlight={i === openEvent}
-            onClick={() => setOpenEvent(i)}
+            highlight={i === eventIndex}
+            onClick={() =>
+              // persist selected eventTab when changing events.
+              navigate(
+                ['/cup', cup.ShortName, 'events', i + 1, eventTab]
+                  .filter(Boolean)
+                  .join('/'),
+              )
+            }
           >
             <EventNo>{i + 1}.</EventNo>
             <RightSide>
@@ -105,49 +115,53 @@ const Cups = props => {
           </EventContainer>
         ))}
       </Grid>
-      {openEvent > -1 && (
-        <Grid item xs={12} sm={6}>
-          <Tabs
-            variant="scrollable"
-            scrollButtons="auto"
-            value={tab}
-            onChange={(e, value) => setTab(value)}
-          >
-            <Tab label="Results" />
-            {events[openEvent].StartTime < format(new Date(), 't') && (
-              <Tab label="Map" />
-            )}
-            {events[openEvent].EndTime < format(new Date(), 't') && (
-              <Tab label="Interviews" />
-            )}
-            {events[openEvent].EndTime < format(new Date(), 't') && (
-              <Tab label="Leaders" />
-            )}
-          </Tabs>
-          {tab === 0 && (
-            <CupResults
-              CupIndex={events[openEvent].CupIndex}
-              ShortName={cup.ShortName}
-              eventNo={openEvent + 1}
-              results={events[openEvent].CupTimes}
-            />
-          )}
-          {tab === 1 && events[openEvent].StartTime < format(new Date(), 't') && (
-            <PlayerContainer>
-              <Recplayer
-                lev={`${config.dlUrl}level/${events[openEvent].LevelIndex}`}
-                controls
+      {(() => {
+        const hasEnded = event.StartTime < format(new Date(), 't');
+
+        return (
+          <Grid item xs={12} sm={6}>
+            <Tabs
+              variant="scrollable"
+              scrollButtons="auto"
+              value={eventTab}
+              onChange={(e, value) => {
+                navigate(
+                  ['/cup', cup.ShortName, 'events', eventNumber, value]
+                    .filter(Boolean)
+                    .join('/'),
+                );
+              }}
+            >
+              <Tab label="Results" value="results" />
+              {hasEnded && <Tab label="Map" value="map" />}
+              {hasEnded && <Tab label="Interviews" value="interviews" />}
+              {hasEnded && <Tab label="Leaders" value="leaders" />}
+            </Tabs>
+            {eventTab === 'results' && (
+              <CupResults
+                CupIndex={event.CupIndex}
+                ShortName={cup.ShortName}
+                eventNo={eventIndex + 1}
+                results={event.CupTimes}
               />
-            </PlayerContainer>
-          )}
-          {tab === 2 && events[openEvent].EndTime < format(new Date(), 't') && (
-            <Interviews cup={cup} event={events[openEvent]} />
-          )}
-          {tab === 3 && events[openEvent].EndTime < format(new Date(), 't') && (
-            <Leaders event={events[openEvent]} />
-          )}
-        </Grid>
-      )}
+            )}
+            {eventTab === 'map' && hasEnded && (
+              <PlayerContainer>
+                <Recplayer
+                  lev={`${config.dlUrl}level/${events[eventIndex].LevelIndex}`}
+                  controls
+                />
+              </PlayerContainer>
+            )}
+            {eventTab === 'interviews' && hasEnded && (
+              <Interviews cup={cup} event={events[eventIndex]} />
+            )}
+            {eventTab === 'leaders' && hasEnded && (
+              <Leaders event={events[eventIndex]} />
+            )}
+          </Grid>
+        );
+      })()}
     </Grid>
   );
 };

--- a/src/pages/home/cards/FeedCard.js
+++ b/src/pages/home/cards/FeedCard.js
@@ -4,12 +4,12 @@ import CardHeader from '@material-ui/core/CardHeader';
 import CardContent from '@material-ui/core/CardContent';
 import CupWidget from 'components/CupWidget';
 
-export default function FeedCard() {
+export default function FeedCard({ cupShortName }) {
   return (
     <Card>
       <CardHeader title="Feed" />
       <CardContent>
-        <CupWidget ShortName="CPC" />
+        <CupWidget ShortName={cupShortName} />
       </CardContent>
     </Card>
   );

--- a/src/pages/home/index.js
+++ b/src/pages/home/index.js
@@ -35,7 +35,7 @@ export default function Home() {
             <CurrentBattleCard />
           </Grid>
           <Grid item xs={12}>
-            <FeedCard />
+            <FeedCard cupShortName="CPC" />
           </Grid>
           <Grid item xs={12}>
             <News amount={5} />

--- a/src/router.js
+++ b/src/router.js
@@ -47,7 +47,7 @@ const Routes = () => {
       <Battles path="battles" />
       <ChatLog path="chatlog" />
       <Confirm path="confirm/:confirmCode" />
-      <Cup path="cup/:ShortName" />
+      <Cup path="cup/:ShortName/*" />
       <CupReplay path="r/cup/:ReplayIndex/:Filename" ReplayType="cup" />
       <Cups path="cups" />
       <Editor path="editor" />


### PR DESCRIPTION
- /cup/shortName/events/1 goes to first event (index 0)
- sub tabs on event tab are persistent, if you click map and switch events, it stays on map
- home page feed card, "Event ##" links to /cup/name/events/##/map
- there might be other places on the site that can now link to relevant cup pages.