### PR TITLE
fix(battle): overflow auto in battle results table

### DIFF
--- a/src/pages/battle/LevelStatsContainer.js
+++ b/src/pages/battle/LevelStatsContainer.js
@@ -152,6 +152,7 @@ const Root = styled.div`
   float: left;
   padding: 7px;
   box-sizing: border-box;
+  overflow: auto;
   @media screen and (max-width: 1100px) {
     float: none;
     width: 100%;


### PR DESCRIPTION
puts scroll bar on table instead of the page on mobile.

![image](https://user-images.githubusercontent.com/24510397/110972103-a203fc00-8329-11eb-96d2-8180b2f75823.png)
