### PR TITLE
feat(levels): add leader history for level

### DIFF
--- a/src/components/LeaderHistory.js
+++ b/src/components/LeaderHistory.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Time from 'components/Time';
 import LocalTime from 'components/LocalTime';
 import styled from 'styled-components';
+import Loading from 'components/Loading';
 
 const TimelineLine = styled.span`
   position: absolute;
@@ -81,46 +82,54 @@ const TimelineMarker = styled.span`
   position: relative;
 `;
 
-export default function LeaderHistory({ allFinished }) {
+const Container = styled.div`
+  padding: 20px;
+`;
+
+export default function LeaderHistory({ allFinished, loading }) {
+  if (loading) return <Loading />;
+
   return (
-    <TimeDevelopment>
-      {[...allFinished]
-        .reduce((acc, cur) => {
-          if (acc.length < 1 || acc[acc.length - 1].Time > cur.Time)
-            acc.push(cur);
-          return acc;
-        }, [])
-        .map((b, i, a) => (
-          <TimeDevelopmentRow key={b.TimeIndex}>
-            <TimeDiff>
-              {a.length > 1 && !a[i + 1] && 'Winner'}
-              {a[i - 1] && (
-                <span>
-                  {' '}
-                  -<Time time={a[i - 1].Time - b.Time} />
-                </span>
-              )}
-              {a.length > 1 && !a[i - 1] && 'First finish'}
-              {a.length === 1 && allFinished.length !== 1 && 'First finish'}
-              {a.length === 1 && allFinished.length === 1 && 'Only finish'}
-            </TimeDiff>
-            <TimelineCell>
-              <TimelineMarker />
-              <TimelineLine />
-            </TimelineCell>
-            <TimeDevelopmentTime>
-              <Time time={b.Time} />
-            </TimeDevelopmentTime>
-            <TimeDevelopmentKuski>{b.KuskiData.Kuski}</TimeDevelopmentKuski>
-            <TimeDevelopmentLocalTime>
-              <LocalTime
-                date={b.Driven}
-                format="ddd D MMM YYYY HH:mm:ss"
-                parse="X"
-              />
-            </TimeDevelopmentLocalTime>
-          </TimeDevelopmentRow>
-        ))}
-    </TimeDevelopment>
+    <Container>
+      <TimeDevelopment>
+        {[...allFinished]
+          .reduce((acc, cur) => {
+            if (acc.length < 1 || acc[acc.length - 1].Time > cur.Time)
+              acc.push(cur);
+            return acc;
+          }, [])
+          .map((b, i, a) => (
+            <TimeDevelopmentRow key={b.TimeIndex}>
+              <TimeDiff>
+                {a.length > 1 && !a[i + 1] && 'Winner'}
+                {a[i - 1] && (
+                  <span>
+                    {' '}
+                    -<Time time={a[i - 1].Time - b.Time} />
+                  </span>
+                )}
+                {a.length > 1 && !a[i - 1] && 'First finish'}
+                {a.length === 1 && allFinished.length !== 1 && 'First finish'}
+                {a.length === 1 && allFinished.length === 1 && 'Only finish'}
+              </TimeDiff>
+              <TimelineCell>
+                <TimelineMarker />
+                <TimelineLine />
+              </TimelineCell>
+              <TimeDevelopmentTime>
+                <Time time={b.Time} />
+              </TimeDevelopmentTime>
+              <TimeDevelopmentKuski>{b.KuskiData.Kuski}</TimeDevelopmentKuski>
+              <TimeDevelopmentLocalTime>
+                <LocalTime
+                  date={b.Driven}
+                  format="ddd D MMM YYYY HH:mm:ss"
+                  parse="X"
+                />
+              </TimeDevelopmentLocalTime>
+            </TimeDevelopmentRow>
+          ))}
+      </TimeDevelopment>
+    </Container>
   );
 }

--- a/src/pages/level/StatsTable.js
+++ b/src/pages/level/StatsTable.js
@@ -6,6 +6,7 @@ import Time from 'components/Time';
 import Loading from 'components/Loading';
 import _ from 'lodash';
 import { nickId } from 'utils/nick';
+import LeaderHistory from 'components/LeaderHistory';
 
 const finishedTypes = {
   B: 'Finished (Apple Bug)',
@@ -16,7 +17,7 @@ const finishedTypes = {
   X: 'Cheated',
 };
 
-const StatsTable = ({ data, loading }) => {
+const StatsTable = ({ data, loading, leaderHistory }) => {
   if (loading) return <Loading />;
 
   if (!nickId()) return <Container>Log in to see personal stats.</Container>;
@@ -38,59 +39,62 @@ const StatsTable = ({ data, loading }) => {
   };
 
   return (
-    <ListContainer>
-      <ListHeader>
-        <ListCell right width={100}>
-          Type
-        </ListCell>
-        <ListCell right width={200}>
-          Total runs
-        </ListCell>
-        <ListCell right width={200}>
-          Time played
-        </ListCell>
-        <ListCell right width={200}>
-          Total runs %
-        </ListCell>
-        <ListCell right width={200}>
-          Time played %
-        </ListCell>
-      </ListHeader>
-      <ListRow>
-        <ListCell right width={100}>
-          All
-        </ListCell>
-        <ListCell right width={200}>
-          {getTotalRunCount()}
-        </ListCell>
-        <ListCell right width={200}>
-          {getTotalTimeSum() !== 0 && <Time time={getTotalTimeSum()} />}
-        </ListCell>
-        <ListCell />
-        <ListCell />
-      </ListRow>
-      {data.map(row => {
-        return (
-          <ListRow>
-            <ListCell right width={100}>
-              {finishedTypes[row.Finished]}
-            </ListCell>
-            <ListCell right width={200}>
-              {row.RunCount}
-            </ListCell>
-            <ListCell right width={200}>
-              {row.TimeSum !== 0 && <Time time={row.TimeSum} />}
-            </ListCell>
-            <ListCell right width={200}>
-              {getRunCountPercentage(row.RunCount) || null}
-            </ListCell>
-            <ListCell right width={200}>
-              {getTimeSumPercentage(row.TimeSum) || null}
-            </ListCell>
-          </ListRow>
-        );
-      })}
-    </ListContainer>
+    <>
+      <ListContainer>
+        <ListHeader>
+          <ListCell right width={100}>
+            Type
+          </ListCell>
+          <ListCell right width={200}>
+            Total runs
+          </ListCell>
+          <ListCell right width={200}>
+            Time played
+          </ListCell>
+          <ListCell right width={200}>
+            Total runs %
+          </ListCell>
+          <ListCell right width={200}>
+            Time played %
+          </ListCell>
+        </ListHeader>
+        <ListRow>
+          <ListCell right width={100}>
+            All
+          </ListCell>
+          <ListCell right width={200}>
+            {getTotalRunCount()}
+          </ListCell>
+          <ListCell right width={200}>
+            {getTotalTimeSum() !== 0 && <Time time={getTotalTimeSum()} />}
+          </ListCell>
+          <ListCell />
+          <ListCell />
+        </ListRow>
+        {data.map(row => {
+          return (
+            <ListRow>
+              <ListCell right width={100}>
+                {finishedTypes[row.Finished]}
+              </ListCell>
+              <ListCell right width={200}>
+                {row.RunCount}
+              </ListCell>
+              <ListCell right width={200}>
+                {row.TimeSum !== 0 && <Time time={row.TimeSum} />}
+              </ListCell>
+              <ListCell right width={200}>
+                {getRunCountPercentage(row.RunCount) || null}
+              </ListCell>
+              <ListCell right width={200}>
+                {getTimeSumPercentage(row.TimeSum) || null}
+              </ListCell>
+            </ListRow>
+          );
+        })}
+      </ListContainer>
+      <LeaderHistory allFinished={leaderHistory} />
+    </>
   );
 };
 

--- a/src/pages/level/index.js
+++ b/src/pages/level/index.js
@@ -33,6 +33,8 @@ import config from 'config';
 import { sortResults, battleStatus, battleStatusBgColor } from 'utils/battle';
 import TimeTable from './TimeTable';
 import StatsTable from './StatsTable';
+import { nickId } from 'utils/nick';
+import LeaderHistory from 'components/LeaderHistory';
 
 const Level = ({ LevelId }) => {
   const LevelIndex = parseInt(LevelId, 10);
@@ -51,6 +53,9 @@ const Level = ({ LevelId }) => {
     timeStats,
     statsLoading,
     settings: { fancyMap },
+    personalLeaderHistory,
+    leaderHistory,
+    leaderHistoryLoading,
   } = useStoreState(state => state.Level);
   const {
     getBesttimes,
@@ -59,6 +64,8 @@ const Level = ({ LevelId }) => {
     getEoltimes,
     getTimeStats,
     toggleFancyMap,
+    getPersonalLeaderHistory,
+    getLeaderHistory,
   } = useStoreActions(actions => actions.Level);
 
   useEffect(() => {
@@ -79,8 +86,17 @@ const Level = ({ LevelId }) => {
       (timeStats.length === 0 || statsLoading !== LevelIndex)
     ) {
       getTimeStats(LevelIndex);
+      if (nickId() > 0) {
+        getPersonalLeaderHistory({ LevelIndex, KuskiIndex: nickId() });
+      }
     }
-    if (value === 3 && (eoltimes.length === 0 || eolLoading !== LevelIndex)) {
+    if (
+      value === 3 &&
+      (leaderHistory.length === 0 || leaderHistoryLoading !== LevelIndex)
+    ) {
+      getLeaderHistory({ LevelIndex });
+    }
+    if (value === 4 && (eoltimes.length === 0 || eolLoading !== LevelIndex)) {
       getEoltimes({ levelId: LevelIndex, limit: 10000, eolOnly: 1 });
     }
   };
@@ -246,6 +262,7 @@ const Level = ({ LevelId }) => {
                 <Tab label="Best times" />
                 <Tab label="All times" />
                 <Tab label="Personal stats" />
+                <Tab label="Leaders" />
                 {level.Legacy && <Tab label="EOL times" />}
               </Tabs>
               {tab === 0 && (
@@ -265,10 +282,17 @@ const Level = ({ LevelId }) => {
               {tab === 2 && (
                 <StatsTable
                   data={timeStats}
+                  leaderHistory={personalLeaderHistory}
                   loading={statsLoading !== LevelIndex}
                 />
               )}
               {tab === 3 && (
+                <LeaderHistory
+                  allFinished={leaderHistory}
+                  loading={leaderHistoryLoading !== LevelIndex}
+                />
+              )}
+              {tab === 4 && (
                 <TimeTable
                   loading={eolLoading !== LevelIndex}
                   data={eoltimes}

--- a/src/pages/level/store.js
+++ b/src/pages/level/store.js
@@ -6,6 +6,7 @@ import {
   BattlesByLevel,
   AllFinishedLevel,
   LevelTimeStats,
+  LeaderHistory,
 } from 'api';
 
 export default {
@@ -19,7 +20,11 @@ export default {
   eoltimes: [],
   eolLoading: 0,
   timeStats: [],
+  personalLeaderHistory: [],
+  leaderHistory: [],
   statsLoading: 0,
+  leaderHistoryLoading: 0,
+  personalLeaderHistoryLoading: 0,
   settings: persist(
     {
       fancyMap: navigator.userAgent.toLowerCase().indexOf('firefox') === -1,
@@ -88,6 +93,32 @@ export default {
     const stats = await LevelTimeStats(payload);
     if (stats.ok) {
       actions.setTimeStats({ data: stats.data, id: payload });
+    }
+  }),
+  setPersonalLeaderHistory: action((state, payload) => {
+    state.personalLeaderHistory = payload.data;
+    state.personalLeaderHistoryLoading = payload.id;
+  }),
+  getPersonalLeaderHistory: thunk(async (actions, payload) => {
+    const leaderHistory = await LeaderHistory(payload);
+    if (leaderHistory.ok) {
+      actions.setPersonalLeaderHistory({
+        data: leaderHistory.data,
+        id: payload.LevelIndex,
+      });
+    }
+  }),
+  setLeaderHistory: action((state, payload) => {
+    state.leaderHistory = payload.data;
+    state.leaderHistoryLoading = payload.id;
+  }),
+  getLeaderHistory: thunk(async (actions, payload) => {
+    const leaderHistory = await LeaderHistory(payload);
+    if (leaderHistory.ok) {
+      actions.setLeaderHistory({
+        data: leaderHistory.data,
+        id: payload.LevelIndex,
+      });
     }
   }),
 };


### PR DESCRIPTION
- new tab `Leaders`
- adds also personal leader history to `Personal Stats` tab