### PR TITLE
refactor(ui): use MUI Rating component for Stars

### DIFF
--- a/src/components/Stars.js
+++ b/src/components/Stars.js
@@ -1,51 +1,36 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { Star, StarBorder } from '@material-ui/icons';
+import { StarBorder } from '@material-ui/icons';
+import Rating from '@material-ui/lab/Rating';
 
-const ten = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-
-const Stars = props => {
-  const { voted, average, vote, clickable } = props;
-  return (
-    <Container>
-      <StarContainer>
-        {ten.map(t => (
-          <StarColor clickable={clickable} onClick={() => vote(t)} key={t}>
-            {t <= voted ? <Star /> : <StarBorder />}
-          </StarColor>
-        ))}
-      </StarContainer>
-      <Rating>{+average.toFixed(2)}</Rating>
-    </Container>
-  );
-};
+const Stars = ({ voted, average, vote, clickable }) => (
+  <Container>
+    <Rating
+      name="replay-rating"
+      value={voted}
+      onChange={(_event, newValue) => {
+        vote(newValue);
+      }}
+      emptyIcon={<StarBorder fontSize="inherit" />}
+      readOnly={!clickable}
+      max={10}
+    />
+    <AverageRating>{Number(average)?.toFixed(2)}</AverageRating>
+  </Container>
+);
 
 const Container = styled.div`
+  font-size: 16px;
   height: 19px;
   display: flex;
   flex-direction: row;
+  align-items: center;
 `;
 
-const StarContainer = styled.div`
-  margin-right: 2px;
-  margin-top: -3px;
-`;
-
-const Rating = styled.div`
-  font-size: 16px;
+const AverageRating = styled.div`
+  margin-left: 0.35em;
   font-weight: bold;
-  line-height: 16px;
-`;
-
-const StarColor = styled.span`
-  cursor: ${props => (props.clickable ? 'pointer' : 'auto')};
-  svg {
-    color: #e4bb24;
-    &:hover {
-      color: ${props => (props.clickable ? 'black' : '#e4bb24')};
-    }
-  }
 `;
 
 Stars.propTypes = {

--- a/src/features/ReplayRating/index.js
+++ b/src/features/ReplayRating/index.js
@@ -13,8 +13,10 @@ const ReplayRating = props => {
   const { getRatings, addRating } = useStoreActions(
     actions => actions.ReplayRating,
   );
+  const isCurrentReplay = lastReplayIndex !== ReplayIndex;
+
   useEffect(() => {
-    if (lastReplayIndex !== ReplayIndex) {
+    if (isCurrentReplay) {
       getRatings(ReplayIndex);
     }
   }, []);
@@ -41,7 +43,7 @@ const ReplayRating = props => {
 
   return (
     <Stars
-      clickable={nickId() > 0}
+      clickable={nickId() > 0 && isCurrentReplay}
       voted={userRating}
       average={avg}
       vote={rating => rate(rating)}


### PR DESCRIPTION
Was just going to fix text alignment, but then Ismo mentioned this existed so I did some more things:

- Refactor Stars component to use [the MUI Rating component](https://material-ui.com/components/rating/)
- Fixes potential bug with this code: `+average.toFixed(2)` (unclear if this was intended or not). I think the idea was to force the `average` to be a number so that you could use `.toFixed()` on it? In which case it was a bug, since it would try to do `.toFixed()` first, then cast the resulting string back to a number. Though isn't it always a number anyway? 🤷‍♀️Not sure if any of this is necessary in the first place
- Vertically aligns the average rating text with the star icons
- Disables voting until you get the data for the actual replay