### PR TITLE
fix(ui): replay rating vote bug

### DIFF
--- a/src/features/ReplayRating/index.js
+++ b/src/features/ReplayRating/index.js
@@ -13,13 +13,13 @@ const ReplayRating = props => {
   const { getRatings, addRating } = useStoreActions(
     actions => actions.ReplayRating,
   );
-  const isCurrentReplay = lastReplayIndex !== ReplayIndex;
+  const isCurrentReplay = lastReplayIndex === ReplayIndex;
 
   useEffect(() => {
-    if (isCurrentReplay) {
+    if (!isCurrentReplay) {
       getRatings(ReplayIndex);
     }
-  }, []);
+  }, [ReplayIndex, isCurrentReplay]);
 
   const rate = rating => {
     if (nick()) {
@@ -35,17 +35,15 @@ const ReplayRating = props => {
   if (ratings.length > 0) {
     avg =
       ratings.reduce((total, next) => total + next.Vote, 0) / ratings.length;
-    const findUserRating = ratings.filter(r => r.KuskiIndex === nickId());
-    if (findUserRating.length > 0) {
-      userRating = findUserRating[0].Vote;
-    }
+    const findUserRating = ratings.find(r => r.KuskiIndex === nickId());
+    userRating = findUserRating?.Vote ?? 0;
   }
 
   return (
     <Stars
       clickable={nickId() > 0 && isCurrentReplay}
-      voted={userRating}
-      average={avg}
+      voted={isCurrentReplay && userRating}
+      average={isCurrentReplay && avg}
       vote={rating => rate(rating)}
     />
   );


### PR DESCRIPTION
I introduced a new bug and there was already a previous bug present 🤐

This should properly check that we have the correct replay and get ratings when it changes. Previously moving from replay to replay would never update the ratings because of the useEffect missing dependency.

Still feels really hacky and dumb though...