### PR TITLE
fix(replayComments): don't show comments from last rec

### DIFF
--- a/src/features/ReplayComments/index.js
+++ b/src/features/ReplayComments/index.js
@@ -12,11 +12,16 @@ const ReplayComments = props => {
   const getComments = useStoreActions(
     actions => actions.ReplayComments.getComments,
   );
+
+  // note that replay/index.js sometimes passes us old replay ID,
+  // which has to do with it accepting replayUUID in props (which is not the ID),
+  // and then having to fetch the replay before knowing the ID.
+  // therefore, the 2nd param below is necessary.
   useEffect(() => {
     if (lastReplayIndex !== ReplayIndex) {
       getComments(ReplayIndex);
     }
-  }, []);
+  }, [ReplayIndex, lastReplayIndex]);
 
   return <Comments comments={commentlist} loading={false} />;
 };


### PR DESCRIPTION
I actually thought the previous logic made sense because the effect would re-run every time component gets mounted, but for some reason it sometimes does not run when navigating to other replays, i don't know why. It's intermittent but you if you click enough replays on live site you'll see its often broken due to not re-running the network request.