### PR TITLE
feat(levelpack): crippled best times and personal records

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "google-map-react": "^2.1.9",
     "level-editor-gui": "https://github.com/elmadev/level-editor-gui.git",
     "lodash": "^4.17.21",
+    "memoizee": "^0.4.15",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",
     "nanoid": "^3.1.22",

--- a/src/api.js
+++ b/src/api.js
@@ -157,9 +157,18 @@ export const CrippledPersonal = (LevelIndex, KuskiIndex = 0, cripple, limit) =>
 export const CrippledTimeStats = (LevelIndex, KuskiIndex = 0, cripple) =>
   api.get(`crippled/timeStats/${LevelIndex}/${KuskiIndex}/${cripple}`);
 
+export const CrippledLevelPackBestTimes = (LevelPackName, topX = 10) =>
+  api.get(`crippled/levelPackBestTimes/${LevelPackName}`, { topX });
+
+export const CrippledLevelPackPersonalRecords = (LevelPackName, KuskiIndex) =>
+  api.get(`crippled/levelPackPersonalRecords/${LevelPackName}/${KuskiIndex}`);
+
 // levelpack
 export const LevelPacks = () => api.get('levelpack');
-export const LevelPack = LevelPackName => api.get(`levelpack/${LevelPackName}`);
+export const LevelPack = (LevelPackName, levels = 0) =>
+  api.get(`levelpack/${LevelPackName}`, {
+    levels: levels ? '1' : undefined,
+  });
 export const TotalTimes = data =>
   api.get(`levelpack/${data.levelPackIndex}/totaltimes/${data.eolOnly}`);
 export const PersonalTimes = data =>

--- a/src/components/Kuski.js
+++ b/src/components/Kuski.js
@@ -20,7 +20,7 @@ const Kuski = ({ kuskiData, team, flag, noLink }) => (
             {kuskiData.Kuski && kuskiData.Kuski}
           </Link>
         )}
-        {team && kuskiData.TeamData && (
+        {team && kuskiData?.TeamData?.Team && (
           <>
             {' '}
             {noLink ? (

--- a/src/pages/levelpack/Crippled.js
+++ b/src/pages/levelpack/Crippled.js
@@ -1,0 +1,410 @@
+import React from 'react';
+import styled from 'styled-components';
+import { ListCell, ListContainer, ListHeader, ListRow } from 'components/List';
+import { isEmpty } from 'lodash';
+import Kuski from 'components/Kuski';
+import Time from 'components/Time';
+import { Level } from 'components/Names';
+import Loading from 'components/Loading';
+import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
+import { useNavigate } from '@reach/router';
+import { parsedTimeToString, parseTimeHundreds } from '../../utils/recTime';
+
+const cripples = [
+  'noVolt',
+  'noTurn',
+  'oneTurn',
+  'noBrake',
+  'noThrottle',
+  'alwaysThrottle',
+  'oneWheel',
+  'drunk',
+];
+
+const NotFinished = () => {
+  return <span title="Not finished">--</span>;
+};
+
+const getTimes = (times, LevelIndex, cripple, count, fill = false) => {
+  const ts = times?.[LevelIndex]?.[cripple];
+  const ret = Array.isArray(ts) ? ts.slice(0, count) : [];
+
+  if (fill) {
+    while (ret.length < count) {
+      ret.push(null);
+    }
+  }
+
+  return ret;
+};
+
+const getBestTime = (times, LevelIndex, crippleType) => {
+  const ts = getTimes(times, LevelIndex, crippleType, 1);
+  return ts.length > 0 ? ts[0] : null;
+};
+
+const getPersonalBestEtc = (
+  personalRecordsPayload,
+  bestTimesPayload,
+  LevelIndex,
+  crippleType,
+) => {
+  const personalBest = getBestTime(
+    personalRecordsPayload,
+    LevelIndex,
+    crippleType,
+  );
+  const topX = getTimes(bestTimesPayload, LevelIndex, crippleType, 9999, false);
+
+  if (personalBest === null) {
+    return [null, null, null];
+  }
+
+  let place = null;
+
+  topX.forEach((time, index) => {
+    if (place === null && time.TimeIndex === personalBest.TimeIndex) {
+      place = index + 1;
+    }
+  });
+
+  // if pb === best time, diff is negative.
+  let diff = null;
+
+  if (topX[0] !== undefined) {
+    if (personalBest.TimeIndex === topX[0].TimeIndex) {
+      if (topX[1] !== undefined) {
+        diff = personalBest.Time - topX[1].Time;
+      }
+    } else {
+      diff = personalBest.Time - topX[0].Time;
+    }
+  }
+
+  return [personalBest, place, diff];
+};
+
+// for cripple === 'all'
+const BestTimeCell = ({ time, loaded }) => {
+  if (!loaded) {
+    return <ListCell />;
+  }
+
+  if (time === null) {
+    return (
+      <ListCell textAlign="center">
+        <NotFinished />
+      </ListCell>
+    );
+  }
+
+  return (
+    <ListCell textAlign="center">
+      <Kuski
+        kuskiData={{
+          Kuski: time.Kuski,
+          Country: time.Country,
+          Team: time.Team,
+        }}
+        flag={true}
+      />
+      <LineSep />
+      <Time time={time.Time} />
+    </ListCell>
+  );
+};
+
+// for crippleType === 'all-personal'
+const PersonalTimeCell = ({
+  personalRecords,
+  bestTimes,
+  LevelIndex,
+  crippleType,
+}) => {
+  if (bestTimes[0] !== 'done' || personalRecords[0] !== 'done') {
+    return <ListCell />;
+  }
+
+  const [time, place, diff] = getPersonalBestEtc(
+    personalRecords[1],
+    bestTimes[1],
+    LevelIndex,
+    crippleType,
+  );
+
+  if (time === null) {
+    return (
+      <ListCell textAlign="center">
+        <NotFinished />
+      </ListCell>
+    );
+  }
+
+  return (
+    <ListCell textAlign="center">
+      <>
+        <Time time={time.Time} />
+        <LineSep />
+        {diff !== null && (
+          <TimeDiff
+            goodColor={diff <= 0}
+            title="Time difference, and place (if top 10)."
+          >
+            {diff >= 0 ? '+' : '-'}
+            {parsedTimeToString(parseTimeHundreds(Math.abs(diff)), false)}
+            {place > 0 && ` (${place})`}
+          </TimeDiff>
+        )}
+      </>
+    </ListCell>
+  );
+};
+
+// for crippleType === 'all' || 'all-personal'
+const TableAllTypes = ({ levels, bestTimes, personalRecords, isPersonal }) => {
+  return (
+    <ListContainer>
+      <ListHeader>
+        <ListCell width={120}>Level</ListCell>
+        <ListCell textAlign="center">No Volt</ListCell>
+        <ListCell textAlign="center">No Turn</ListCell>
+        <ListCell textAlign="center">One Turn</ListCell>
+        <ListCell textAlign="center">No Brake</ListCell>
+        <ListCell textAlign="center">No Throttle</ListCell>
+        <ListCell textAlign="center">Always Throttle</ListCell>
+        <ListCell textAlign="center">One Wheel</ListCell>
+        <ListCell textAlign="center">Drunk</ListCell>
+      </ListHeader>
+      {levels.map(level => {
+        return (
+          <ListRow key={level.LevelIndex}>
+            <ListCell>
+              <Level LevelIndex={level.LevelIndex} LevelData={level.Level} />
+              <LineSep />
+              <span>{level.Level.LongName}</span>
+            </ListCell>
+            {!isPersonal &&
+              cripples.map(cripple => {
+                return (
+                  <BestTimeCell
+                    loaded={bestTimes[0] === 'done'}
+                    time={getBestTime(bestTimes[1], level.LevelIndex, cripple)}
+                  />
+                );
+              })}
+            {isPersonal &&
+              cripples.map(cripple => {
+                return (
+                  <PersonalTimeCell
+                    personalRecords={personalRecords}
+                    bestTimes={bestTimes}
+                    LevelIndex={level.LevelIndex}
+                    crippleType={cripple}
+                  />
+                );
+              })}
+          </ListRow>
+        );
+      })}
+    </ListContainer>
+  );
+};
+
+const TableByType = ({
+  levels,
+  bestTimes,
+  personalRecords,
+  loggedIn,
+  crippleType,
+}) => {
+  const bestTimesLoaded = bestTimes[0] === 'done';
+  const personalRecordsLoaded = personalRecords[0] === 'done';
+
+  return (
+    <ListContainer>
+      <ListHeader>
+        <ListCell width={100}>Filename</ListCell>
+        <ListCell width={320}>Level name</ListCell>
+        <ListCell width={200}>Kuski</ListCell>
+        <ListCell width={130}>Time</ListCell>
+        <ListCell>{loggedIn && 'Personal'}</ListCell>
+        <ListCell />
+      </ListHeader>
+
+      {levels.map(level => {
+        const bestTime = getBestTime(
+          bestTimes[1],
+          level.LevelIndex,
+          crippleType,
+        );
+
+        const [personalBest, personalPlace] = getPersonalBestEtc(
+          personalRecords[1],
+          bestTimes[1],
+          level.LevelIndex,
+          crippleType,
+        );
+
+        return (
+          <ListRow key={level.LevelIndex}>
+            <ListCell>
+              <Level LevelIndex={level.LevelIndex} LevelData={level.Level} />
+            </ListCell>
+            <ListCell>
+              <span>{level.Level.LongName}</span>
+            </ListCell>
+            <ListCell>
+              {bestTime !== null && (
+                <Kuski
+                  kuskiData={{
+                    Kuski: bestTime.Kuski,
+                    Country: bestTime.Country,
+                    TeamData: {
+                      Team: bestTime.Team,
+                    },
+                  }}
+                  flag={true}
+                  team={true}
+                />
+              )}
+            </ListCell>
+            <ListCell>
+              {bestTimesLoaded && bestTime === null && <NotFinished />}
+              {bestTimesLoaded && bestTime !== null && (
+                <Time time={bestTime.Time} />
+              )}
+            </ListCell>
+            <ListCell>
+              {loggedIn && bestTimesLoaded && personalRecordsLoaded && (
+                <>
+                  {personalPlace === 1 && (
+                    <span title="First Place">Record</span>
+                  )}
+                  {personalPlace < 1 && <NotFinished />}
+                  {personalPlace > 1 && (
+                    <span title="Time, and place (if top 10)">
+                      <Time time={personalBest.Time} />
+                      {personalPlace > 1 ? ` (${personalPlace})` : ``}
+                    </span>
+                  )}
+                </>
+              )}
+            </ListCell>
+            <ListCell />
+          </ListRow>
+        );
+      })}
+    </ListContainer>
+  );
+};
+
+const Crippled = ({
+  LevelPack,
+  bestTimes,
+  personalRecords,
+  crippleType,
+  loggedIn,
+}) => {
+  const levels = isEmpty(LevelPack) ? [] : LevelPack.levels;
+  const navigate = useNavigate();
+
+  return (
+    <Root>
+      <Controls>
+        <CrippleSelect>
+          <InputLabel id="cripple">Cripple</InputLabel>
+          <Select
+            id="cripple"
+            value={crippleType}
+            onChange={e => {
+              navigate(
+                [
+                  '/levels/packs',
+                  LevelPack.LevelPackName,
+                  'crippled',
+                  e.target.value,
+                ]
+                  .filter(Boolean)
+                  .join('/'),
+              );
+            }}
+          >
+            <MenuItem value="noVolt">No Volt</MenuItem>
+            <MenuItem value="noTurn">No Turn</MenuItem>
+            <MenuItem value="oneTurn">One Turn</MenuItem>
+            <MenuItem value="noBrake">No Brake</MenuItem>
+            <MenuItem value="noThrottle">No Throttle</MenuItem>
+            <MenuItem value="alwaysThrottle">Always Throttle</MenuItem>
+            <MenuItem value="oneWheel">One Wheel</MenuItem>
+            <MenuItem value="drunk">Drunk</MenuItem>
+            <MenuItem value="all">All Types</MenuItem>
+            <MenuItem value="all-personal">All Types (Personal)</MenuItem>
+          </Select>
+        </CrippleSelect>
+      </Controls>
+
+      {!crippleType && 'Select a cripple type.'}
+      {bestTimes[0] === 'loading' && <Loading />}
+      {bestTimes[0] === 'error' && 'Error loading data.'}
+
+      {crippleType === 'all' && (
+        <TableAllTypes levels={levels} bestTimes={bestTimes} />
+      )}
+
+      {crippleType === 'all-personal' && (
+        <TableAllTypes
+          levels={levels}
+          bestTimes={bestTimes}
+          personalRecords={personalRecords}
+          isPersonal={true}
+        />
+      )}
+
+      {crippleType &&
+        crippleType !== 'all' &&
+        crippleType !== 'all-personal' && (
+          <TableByType
+            levels={levels}
+            bestTimes={bestTimes}
+            personalRecords={personalRecords}
+            loggedIn={loggedIn}
+            crippleType={crippleType}
+          />
+        )}
+    </Root>
+  );
+};
+
+const Root = styled.div`
+  margin-bottom: 30px;
+`;
+
+const Controls = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 16px;
+  padding-bottom: 25px;
+  && {
+    > * {
+      margin-right: 18px;
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+`;
+
+const LineSep = styled.div`
+  height: 3px;
+`;
+
+const CrippleSelect = styled(FormControl)`
+  min-width: 175px !important;
+`;
+
+const TimeDiff = styled.span`
+  color: ${p => (p.goodColor ? p.theme.primary : p.theme.errorColor)};
+`;
+
+export default Crippled;

--- a/src/pages/levelpack/index.js
+++ b/src/pages/levelpack/index.js
@@ -28,10 +28,12 @@ import TotalTimes from './TotalTimes';
 import Personal from './Personal';
 import Kinglist from './Kinglist';
 import MultiRecords from './MultiRecords';
+import Crippled from './Crippled';
 import Admin from './Admin';
 
-const LevelPack = ({ name, tab }) => {
+const LevelPack = ({ name, tab, ...props }) => {
   const isRehydrated = useStoreRehydrated();
+  const subTab = props['*'];
   const {
     levelPackInfo,
     highlight,
@@ -41,8 +43,11 @@ const LevelPack = ({ name, tab }) => {
     records,
     recordsLoading,
     personalKuski,
+    crippledTimes,
+    crippledPersonalRecords,
     settings: { highlightWeeks, showLegacyIcon, showLegacy },
   } = useStoreState(state => state.LevelPack);
+  const { userid } = useStoreState(state => state.Login);
   const {
     getLevelPackInfo,
     getHighlight,
@@ -52,6 +57,8 @@ const LevelPack = ({ name, tab }) => {
     setHighlightWeeks,
     toggleShowLegacyIcon,
     toggleShowLegacy,
+    getCrippledTimes,
+    getCrippledPersonalRecords,
   } = useStoreActions(actions => actions.LevelPack);
   const lastShowLegacy = useRef(showLegacy);
   const [openSettings, setOpenSettings] = useState(false);
@@ -87,6 +94,16 @@ const LevelPack = ({ name, tab }) => {
     }
   }, [showLegacy]);
 
+  useEffect(() => {
+    if (tab === 'crippled') {
+      getCrippledTimes(name);
+
+      if (userid) {
+        getCrippledPersonalRecords([name, userid]);
+      }
+    }
+  }, [name, tab, userid]);
+
   if (!isRehydrated || !levelPackInfo)
     return (
       <Layout edge t={`Level pack - ${name}`}>
@@ -103,15 +120,22 @@ const LevelPack = ({ name, tab }) => {
           variant="scrollable"
           scrollButtons="auto"
           value={tab}
-          onChange={(e, value) =>
-            navigate(['/levels/packs', name, value].filter(Boolean).join('/'))
-          }
+          onChange={(e, value) => {
+            if (value === 'crippled') {
+              navigate(['/levels/packs', name, 'crippled/noVolt'].join('/'));
+            } else {
+              navigate(
+                ['/levels/packs', name, value].filter(Boolean).join('/'),
+              );
+            }
+          }}
         >
           <Tab label="Records" value="" />
           <Tab label="Total Times" value="total-times" />
           <Tab label="King list" value="king-list" />
           <Tab label="Personal" value="personal" />
           <Tab label="Multi records" value="multi" />
+          <Tab label="Crippled" value="crippled" />
           {adminAuth && <Tab label="Admin" value="admin" />}
         </Tabs>
         <LevelPackName>
@@ -252,6 +276,16 @@ const LevelPack = ({ name, tab }) => {
             highlightWeeks={highlightWeeks}
           />
         )}
+        {tab === 'crippled' && (
+          <Crippled
+            LevelPack={levelPackInfo}
+            bestTimes={crippledTimes}
+            personalRecords={crippledPersonalRecords}
+            crippleType={subTab}
+            loggedIn={userid > 0}
+          />
+        )}
+
         {tab === 'admin' && adminAuth && (
           <Admin records={records} LevelPack={levelPackInfo} />
         )}

--- a/src/pages/levelpack/store.js
+++ b/src/pages/levelpack/store.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-param-reassign */
 import { action, thunk, persist } from 'easy-peasy';
+import memoize from 'memoizee';
 import {
   Highlight,
   PersonalAllFinished,
@@ -15,7 +16,14 @@ import {
   LevelPackSort,
   LevelPack,
   UpdateLevelPack,
+  CrippledLevelPackBestTimes,
+  CrippledLevelPackPersonalRecords,
 } from 'api';
+
+const getCrippledBestTimesCached = memoize(CrippledLevelPackBestTimes);
+const getCrippledPersonalRecordsCached = memoize(
+  CrippledLevelPackPersonalRecords,
+);
 
 export default {
   levelPackInfo: {},
@@ -23,7 +31,7 @@ export default {
     state.levelPackInfo = payload;
   }),
   getLevelPackInfo: thunk(async (actions, payload) => {
-    const get = await LevelPack(payload);
+    const get = await LevelPack(payload, true);
     if (get.ok) {
       actions.setLevelPackInfo(get.data);
     }
@@ -222,6 +230,37 @@ export default {
       });
     } else {
       actions.setAdminLoading(false);
+    }
+  }),
+  crippledTimes: ['idle', {}],
+  setCrippledTimes: action((state, payload) => {
+    state.crippledTimes = payload;
+  }),
+  getCrippledTimes: thunk(async (actions, packName, helpers) => {
+    actions.setCrippledTimes(['loading', {}]);
+    const res = await getCrippledBestTimesCached(packName, 10);
+
+    if (res.ok) {
+      actions.setCrippledTimes(['done', res.data]);
+    } else {
+      actions.setCrippledTimes(['error', res.data]);
+    }
+  }),
+  crippledPersonalRecords: ['idle', {}],
+  setCrippledPersonalRecords: action((state, payload) => {
+    state.crippledPersonalRecords = payload;
+  }),
+  getCrippledPersonalRecords: thunk(async (actions, payload, helpers) => {
+    const [packName, kuskiIndex] = payload;
+
+    actions.setCrippledPersonalRecords(['loading', {}]);
+
+    const res = await getCrippledPersonalRecordsCached(packName, kuskiIndex);
+
+    if (res.ok) {
+      actions.setCrippledPersonalRecords(['done', res.data]);
+    } else {
+      actions.setCrippledPersonalRecords(['error', {}]);
     }
   }),
 };

--- a/src/router.js
+++ b/src/router.js
@@ -70,7 +70,7 @@ const Routes = () => {
           <Kuskis path="kuskis/search" tab="search" />
           <Level path="levels/:LevelId" />
           <LevelPack path="levels/packs/:name" tab="" />
-          <LevelPack path="levels/packs/:name/:tab" />
+          <LevelPack path="levels/packs/:name/:tab/*" />
           <Levels path="levels" tab="" />
           {/* can't use levels/:tab due to conflict with levels/:LevelId above*/}
           <Levels path="levels/collections" tab="collections" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -7148,7 +7148,7 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@~0.10.14:
+es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50, es5-ext@^0.10.53, es5-ext@~0.10.14, es5-ext@~0.10.2, es5-ext@~0.10.46:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
   integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
@@ -7215,7 +7215,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-es6-weak-map@^2.0.1:
+es6-weak-map@^2.0.1, es6-weak-map@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
   integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
@@ -7528,7 +7528,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-event-emitter@~0.3.5:
+event-emitter@^0.3.5, event-emitter@~0.3.5:
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/event-emitter/-/event-emitter-0.3.5.tgz#df8c69eef1647923c7157b9ce83840610b02cc39"
   integrity sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=
@@ -9785,6 +9785,11 @@ is-potential-custom-element-name@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz#0c52e54bcca391bb2c494b21e8626d7336c6e397"
   integrity sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
 
+is-promise@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
+  integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
 is-regex@^1.0.4, is-regex@^1.1.0, is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
@@ -11122,6 +11127,13 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lru-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/lru-queue/-/lru-queue-0.1.0.tgz#2738bd9f0d3cf4f84490c5736c48699ac632cda3"
+  integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
+  dependencies:
+    es5-ext "~0.10.2"
+
 lz-string@^1.4.4:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
@@ -11278,6 +11290,20 @@ mem@^1.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==
+
+memoizee@^0.4.15:
+  version "0.4.15"
+  resolved "https://registry.yarnpkg.com/memoizee/-/memoizee-0.4.15.tgz#e6f3d2da863f318d02225391829a6c5956555b72"
+  integrity sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==
+  dependencies:
+    d "^1.0.1"
+    es5-ext "^0.10.53"
+    es6-weak-map "^2.0.3"
+    event-emitter "^0.3.5"
+    is-promise "^2.2.2"
+    lru-queue "^0.1.0"
+    next-tick "^1.1.0"
+    timers-ext "^0.1.7"
 
 memoizerific@^1.11.3:
   version "1.11.3"
@@ -11645,6 +11671,11 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz#0fbdcf3e13fe4994781280524f8b96b0cdff9c61"
   integrity sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug==
+
+next-tick@1, next-tick@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
+  integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
 
 next-tick@~1.0.0:
   version "1.0.0"
@@ -15989,6 +16020,14 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
+
+timers-ext@^0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/timers-ext/-/timers-ext-0.1.7.tgz#6f57ad8578e07a3fb9f91d9387d65647555e25c6"
+  integrity sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==
+  dependencies:
+    es5-ext "~0.10.46"
+    next-tick "1"
 
 timsort@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
A first working levelpack crippled times feature. Some improvements could be added later:

- Player select box to see other people's personal times.
- Click on level to see top 10's, or global switch to show top 10's for all levels.
- The back-end is currently doing more work than needed for the current features, but, I don't really want to change it now just to change it back in the future. We should monitor performance to make sure things are ok, otherwise we'll have to give up on certain features (like loading all top 10's for all crippled types in one request). Doing it this way lets the all-personal tab show your place if it's a top 10 time for example.
- Maybe link cells to level page with crippled option already selected.
- Some other things but I forget right now.

Performance wise, the main query usually runs for internals in 2-3 seconds, which is in the same ballpark as the normal top times, king list, etc (or mabe faster). However, it can be ~15 sec when table is not loaded into the buffer pool. Not ideal at all, but it's the same for pretty much all queries when other large tables have to be read from disk. I think it probably won't happen too often on the live site. Hard to know.