### PR TITLE
feat(levelstats): various small improvements

### DIFF
--- a/src/components/Names.js
+++ b/src/components/Names.js
@@ -98,4 +98,4 @@ const TypeSpan = styled.span`
   font-size: ${p => (p.small ? '10px' : 'inherit')};
 `;
 
-export { Level, BattleType };
+export { Level, BattleType, formatLevel };

--- a/src/components/RecentRecords.js
+++ b/src/components/RecentRecords.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { ListContainer, ListHeader, ListRow, ListCell } from 'components/List';
 import Link from 'components/Link';
 import Time from 'components/Time';
@@ -10,14 +11,14 @@ const RecentRecords = ({ records }) => {
     <>
       <ListContainer>
         <ListHeader>
-          <ListCell>Record</ListCell>
-          <ListCell>Level</ListCell>
-          <ListCell title="Total time played by all kuski's combined.">
-            Time Played
+          <ListCell>Kuski</ListCell>
+          <ListCell>Time</ListCell>
+          <ListCell title="Level and cumulative playtime on level by all Kuski's">
+            Level
           </ListCell>
           <ListCell>Driven</ListCell>
         </ListHeader>
-        {records &&
+        {Array.isArray(records) &&
           records.map(r => {
             const level = r.LevelData || {};
             const kuski = r.KuskiData || {};
@@ -25,22 +26,23 @@ const RecentRecords = ({ records }) => {
             const driven2 = formatDistance(
               new Date(r.Driven * 1000),
               new Date(),
-              { addSuffix: true },
+              { addSuffix: true, addPrefix: false },
             );
 
             return (
               <ListRow>
                 <ListCell>
-                  <Kuski kuskiData={kuski} flag={true} />
-                  <span>{` `}</span>
+                  <Kuski kuskiData={kuski} flag={true} team={true} />
+                </ListCell>
+                <ListCell>
                   <Time time={r.Time} />
                 </ListCell>
                 <ListCell>
                   <Link to={levUrl} title={level.LongName}>
                     {level.LevelName}
                   </Link>
+                  {` `}({formatTimeSpent(r.TimeAll)})
                 </ListCell>
-                <ListCell>{formatTimeSpent(r.TimeAll)}</ListCell>
                 <ListCell>{driven2}</ListCell>
               </ListRow>
             );

--- a/src/features/ReplayList/index.js
+++ b/src/features/ReplayList/index.js
@@ -239,7 +239,7 @@ const Container = styled.div`
   background: ${p =>
     p.grid ? p.theme.pageBackgroundDark : p.theme.paperBackground};
   min-width: 100%;
-  max-height: ${p => (p.small ? '283px' : 'auto')};
+  max-height: ${p => (p.small ? '243px' : 'auto')};
   overflow: ${p => (p.small ? 'auto' : 'visible')};
   a {
     color: ${p => p.theme.fontColor};

--- a/src/pages/home/cards/BattlesCard.js
+++ b/src/pages/home/cards/BattlesCard.js
@@ -16,7 +16,7 @@ export default function BattlesCard() {
         <BattleList
           start={subYears(new Date(), 1)}
           end={addHours(new Date(), 12)}
-          limit={6}
+          limit={5}
           condensed
         />
       </CardContent>

--- a/src/pages/home/cards/RecordsCard.js
+++ b/src/pages/home/cards/RecordsCard.js
@@ -10,16 +10,11 @@ import { RecentBestRecords, useQueryAlt } from 'api';
 const RecordsCard = () => {
   const [expanded, setExpanded] = useState(false);
 
-  const { data: records } = useQueryAlt(
-    ['RecentBestRecords', 7],
-    async () => RecentBestRecords(7, 100),
-    {
-      // todo: add sensible defaults to query client then remove this
-      staleTime: 60000,
-    },
+  const { data: records } = useQueryAlt(['RecentBestRecords', 7], async () =>
+    RecentBestRecords(7, 100),
   );
 
-  const previewCount = 6;
+  const previewCount = 5;
 
   const show = records
     ? expanded
@@ -31,8 +26,9 @@ const RecordsCard = () => {
 
   return (
     <Card>
-      <CardContent>
-        <Header h2>Best 1st Place Finishes - Last 7 Days</Header>
+      <CardContent title="Records driven during battles are omitted.">
+        <Header h2>Records (Last 7 Days)</Header>
+        <div>Ordered by overall level playtime.</div>
         {records && <RecentRecords records={show} />}
       </CardContent>
       {countMore > 0 && (

--- a/src/pages/kuski/Records.js
+++ b/src/pages/kuski/Records.js
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useQueryAlt, PlayerRecords } from 'api';
 import { ListContainer, ListHeader, ListRow, ListCell } from 'components/List';
+import { formatLevel } from 'components/Names';
 import {
   FormControl,
   InputLabel,
@@ -13,43 +14,15 @@ import Loading from 'components/Loading';
 import Time from 'components/Time';
 import Link from 'components/Link';
 import LocalTime from 'components/LocalTime';
-import { formatTimeSpent } from '../../utils/format';
-
-// ie. table row
-const Record = ({ record }) => {
-  const stats = record.LevelStatsData || {};
-  const level = record.LevelData || {};
-
-  return (
-    <ListRow key={record.TimeIndex}>
-      <ListCell>
-        <Link to={`/levels/${level.LevelIndex}`}>{level.LevelName}</Link>
-      </ListCell>
-      <ListCell>{level.LongName}</ListCell>
-      <ListCell>
-        {stats.KuskiCountF}
-        {`/`}
-        {stats.KuskiCountAll}
-      </ListCell>
-      <ListCell>{stats.LeaderCount}</ListCell>
-      <ListCell>{formatTimeSpent(stats.TimeAll)}</ListCell>
-      <ListCell>
-        <LocalTime
-          date={new Date(record.Driven * 1000)}
-          format="ddd D MMM YYYY HH:mm:ss"
-          parse={undefined}
-        />
-      </ListCell>
-      <ListCell>
-        <Time time={record.Time} />
-      </ListCell>
-    </ListRow>
-  );
-};
+import { formatPct, formatTimeSpent } from 'utils/format';
+import { formatAttempts } from 'utils/format';
+import { useNavigate } from '@reach/router';
 
 // records tab content
-const Records = ({ KuskiIndex, recordCount }) => {
-  const [sort, setSort] = useState('Driven');
+const Records = ({ kuski, sort, recordCount }) => {
+  const KuskiIndex = kuski.KuskiIndex;
+
+  const navigate = useNavigate();
 
   const [page, setPage] = useState(0);
   const [pageSize, setPageSize] = useState(25);
@@ -58,13 +31,13 @@ const Records = ({ KuskiIndex, recordCount }) => {
     ['PlayerRecords', KuskiIndex, sort, page, pageSize],
     async () =>
       PlayerRecords(KuskiIndex, {
-        sort,
+        sort: sort === 'TimeAsc' || sort === 'TimeDesc' ? 'Time' : sort,
         offset: page * pageSize,
         limit: pageSize,
+        reverse: sort === 'TimeDesc' ? '1' : '',
       }),
     {
       enabled: !!KuskiIndex,
-      staleTime: 60000,
     },
   );
 
@@ -91,12 +64,17 @@ const Records = ({ KuskiIndex, recordCount }) => {
           <Select
             id="records-sort"
             value={sort}
-            onChange={e => setSort(e.target.value)}
+            onChange={e => {
+              navigate(`/kuskis/${kuski.Kuski}/records/${e.target.value}`);
+            }}
           >
-            <MenuItem value="Driven">Driven</MenuItem>
+            <MenuItem value="TimeAll">Playtime (All Kuski's)</MenuItem>
+            <MenuItem value="AttemptsAll">Attempts (All Kuski's)</MenuItem>
             <MenuItem value="KuskiCountAll"># Kuski's Played</MenuItem>
             <MenuItem value="LeaderCount">Leader Count</MenuItem>
-            <MenuItem value="TimeAll">Time Played</MenuItem>
+            <MenuItem value="Driven">Driven</MenuItem>
+            <MenuItem value="TimeDesc">Time (High)</MenuItem>
+            <MenuItem value="TimeAsc">Time (Low)</MenuItem>
           </Select>
         </StyledFormControl>
       </Controls>
@@ -104,13 +82,21 @@ const Records = ({ KuskiIndex, recordCount }) => {
         <ListHeader>
           <ListCell>Level</ListCell>
           <ListCell>Long Name</ListCell>
+          <ListCell>Time</ListCell>
+          <ListCell>
+            Playtime <br />
+            (All Kuski's)
+          </ListCell>
+          <ListCell>
+            Attempts <br />
+            (All Kuski's)
+          </ListCell>
           <ListCell title="Number of kuski's that attempted the level">
-            # Kuski's Finished/Played
+            # Kuski's Played <br />
+            (% Finished)
           </ListCell>
           <ListCell title="Size of the leader history">Leader Count</ListCell>
-          <ListCell>Time Played (All Kuski's)</ListCell>
           <ListCell>Driven</ListCell>
-          <ListCell>Time</ListCell>
         </ListHeader>
 
         {records.map(record => (
@@ -118,6 +104,40 @@ const Records = ({ KuskiIndex, recordCount }) => {
         ))}
       </ListContainer>
     </>
+  );
+};
+
+// ie. table row
+const Record = ({ record }) => {
+  const stats = record.LevelStatsData || {};
+  const level = record.LevelData || {};
+
+  return (
+    <ListRow key={record.TimeIndex}>
+      <ListCell>
+        <Link to={`/levels/${level.LevelIndex}`}>
+          {formatLevel(level.LevelName)}
+        </Link>
+      </ListCell>
+      <ListCell>{level.LongName}</ListCell>
+      <ListCell>
+        <Time time={record.Time} />
+      </ListCell>
+      <ListCell>{formatTimeSpent(stats.TimeAll)}</ListCell>
+      <ListCell>{formatAttempts(stats.AttemptsAll)}</ListCell>
+      <ListCell>
+        {stats.KuskiCountAll} (
+        {formatPct(stats.KuskiCountF, stats.KuskiCountAll, 0)}%)
+      </ListCell>
+      <ListCell>{stats.LeaderCount}</ListCell>
+      <ListCell>
+        <LocalTime
+          date={new Date(record.Driven * 1000)}
+          format="ddd D MMM YYYY HH:mm"
+          parse={undefined}
+        />
+      </ListCell>
+    </ListRow>
   );
 };
 

--- a/src/pages/kuski/index.js
+++ b/src/pages/kuski/index.js
@@ -19,8 +19,9 @@ import Info from './Info';
 import Records from './Records';
 import { useQueryAlt, PlayerRecordCount } from 'api';
 import Files from './Files';
+import { isEmpty } from 'lodash';
 
-const Kuski = ({ name, tab, ...props }) => {
+const Kuski = ({ name, tab, recordSort, ...props }) => {
   const { getKuskiByName, setCollapse } = useStoreActions(state => state.Kuski);
   const {
     kuski,
@@ -39,7 +40,6 @@ const Kuski = ({ name, tab, ...props }) => {
     async () => PlayerRecordCount(kuski.KuskiIndex),
     {
       enabled: !!kuski.KuskiIndex,
-      staleTime: 60000,
     },
   );
 
@@ -67,7 +67,10 @@ const Kuski = ({ name, tab, ...props }) => {
                 {kuski.TeamData && `Team: ${kuski.TeamData.Team}`}
               </TeamNat>
             </Profile>
-            <KuskiHeader KuskiIndex={kuski.KuskiIndex} recordCount={recordCount} />
+            <KuskiHeader
+              KuskiIndex={kuski.KuskiIndex}
+              recordCount={recordCount}
+            />
             <Expand>
               {collapse ? (
                 <ExpandMore onClick={() => setCollapse(false)} />
@@ -109,8 +112,12 @@ const Kuski = ({ name, tab, ...props }) => {
           {tab === 'times' && (
             <TimesReplays KuskiIndex={kuski.KuskiIndex} collapse={collapse} />
           )}
-          {tab === 'records' && (
-            <Records KuskiIndex={kuski.KuskiIndex} recordCount={recordCount} />
+          {tab === 'records' && !isEmpty(kuski) && (
+            <Records
+              kuski={kuski}
+              sort={recordSort}
+              recordCount={recordCount}
+            />
           )}
           {tab === 'replays-uploaded' && (
             <Width100>

--- a/src/pages/levelpack/index.js
+++ b/src/pages/levelpack/index.js
@@ -61,9 +61,6 @@ const LevelPack = ({ name, tab }) => {
   const { data: levelStats } = useQueryAlt(
     ['LevelPackLevelStats', 1, name],
     async () => LevelPackLevelStats(1, name),
-    {
-      staleTime: 300000,
-    },
   );
 
   useEffect(() => {

--- a/src/pages/levels/LevelpacksDetailed.js
+++ b/src/pages/levels/LevelpacksDetailed.js
@@ -17,10 +17,11 @@ const LevelpacksDetailed = ({
 }) => {
   const windowSize = useElementSize();
   const listHeight = windowSize.height - 264;
+
   return (
     <Root>
       <Table flex direction="column">
-        <ListHeader>
+        <StyledListHeader>
           <ListCell>
             <NewLineWrapper>Pack</NewLineWrapper>
             <NewLineWrapper>Long Name</NewLineWrapper>
@@ -38,8 +39,8 @@ const LevelpacksDetailed = ({
             <NewLineWrapper>(Dead/Esc/Finished)</NewLineWrapper>
           </ListCell>
           <ListCell>
-            <NewLineWrapper># Finished / # Levels</NewLineWrapper>
-            <NewLineWrapper title="The average number of kuski's that played each level. A good measure of overall popularity.">
+            <NewLineWrapper># Levels (% Finished)</NewLineWrapper>
+            <NewLineWrapper title="The average number of kuski's that played each level.">
               (Avg. Kuski Count)
             </NewLineWrapper>
             <NewLineWrapper>Top Record Holder(s)</NewLineWrapper>
@@ -52,7 +53,7 @@ const LevelpacksDetailed = ({
               Avg. Record Time
             </NewLineWrapper>
           </ListCell>
-        </ListHeader>
+        </StyledListHeader>
         <List
           height={listHeight}
           itemCount={levelpacksSorted.length}
@@ -64,12 +65,9 @@ const LevelpacksDetailed = ({
 
             const url = `/levels/packs/${p.LevelPackName}`;
 
-            const topRecordPct =
-              st && formatPct(st.TopRecordCount, st.LevelCountAll, 0);
-
             return (
               <div style={style} key={p.LevelPackIndex}>
-                <Row>
+                <Row style={style} key={p.LevelPackIndex}>
                   <ListCell to={url}>
                     <ShortName>{p.LevelPackName}</ShortName>
                     <LongName>{p.LevelPackLongName}</LongName>
@@ -135,24 +133,38 @@ const LevelpacksDetailed = ({
                           </ListCell>
                           <ListCell>
                             <NewLineWrapper>
-                              {st.LevelCountF || 0}
-                              {`/`}
                               {st.LevelCountAll || 0}
+                              {` `}(
+                              {formatPct(st.LevelCountF, st.LevelCountAll, 0)}%)
                               {` `}({Number(st.AvgKuskiPerLevel).toFixed(2)})
                             </NewLineWrapper>
-                            {st.TopRecordKuskis && (
-                              <NewLineWrapper>
-                                {st.TopRecordKuskis.map(k => (
-                                  <>
-                                    <Kuski
-                                      key={k.KuskiIndex}
-                                      kuskiData={k}
-                                      flag={true}
-                                    />{' '}
-                                  </>
-                                ))}
-                                {` (${st.TopRecordCount}) (${topRecordPct}%)`}
-                              </NewLineWrapper>
+                            {Array.isArray(st.TopRecordKuskis) && (
+                              <>
+                                {st.TopRecordKuskis.length > 2 && (
+                                  <NewLineWrapper>
+                                    3 or more Kuski's
+                                    {` (${st.TopRecordCount})`}
+                                  </NewLineWrapper>
+                                )}
+
+                                {st.TopRecordKuskis.length <= 2 && (
+                                  <NewLineWrapper>
+                                    {st.TopRecordKuskis.map((k, index, arr) => (
+                                      <>
+                                        <Kuski
+                                          key={k.KuskiIndex}
+                                          kuskiData={k}
+                                          flag={true}
+                                        />
+                                        {index < arr.length - 1 && (
+                                          <span>, </span>
+                                        )}
+                                      </>
+                                    ))}
+                                    {` (${st.TopRecordCount})`}
+                                  </NewLineWrapper>
+                                )}
+                              </>
                             )}
                           </ListCell>
                           <ListCell to={url}>
@@ -182,11 +194,19 @@ const LevelpacksDetailed = ({
   );
 };
 
-const Root = styled.div``;
+const Root = styled.div`
+  overflow: auto;
+`;
 
 const Table = styled(ListContainer)`
   margin-top: 10px;
+  min-width: 1000px;
   background: ${p => p.theme.paperBackground};
+`;
+
+// because of scroll bar in table body
+const StyledListHeader = styled(ListHeader)`
+  padding-right: 17px;
 `;
 
 const Row = styled(ListRow)`

--- a/src/pages/levels/index.js
+++ b/src/pages/levels/index.js
@@ -14,12 +14,33 @@ import LevelpacksDetailed from './LevelpacksDetailed';
 import Controls from './Controls';
 import FavStar from './FavStar';
 
+const getColumnCount = window_width => {
+  if (window_width > 1440) {
+    return 5;
+  }
+
+  if (window_width > 1150) {
+    return 4;
+  }
+
+  if (window_width > 600) {
+    return 3;
+  }
+
+  if (window_width > 400) {
+    return 2;
+  }
+
+  return 1;
+};
+
 const Levels = ({ tab, detailed }) => {
   const GridRef = useRef();
   const navigate = useNavigate();
   const windowSize = useElementSize();
   const listHeight = windowSize.height - 160;
-  const listWidth = windowSize.width - 250;
+  const listWidth =
+    windowSize.width > 1000 ? windowSize.width - 250 : windowSize.width || 0;
 
   const { levelpacksSorted, stats, collections } = useStoreState(
     state => state.Levels,
@@ -100,8 +121,10 @@ const Levels = ({ tab, detailed }) => {
                 {levelpacksSorted.length > 0 && (
                   <Grid
                     ref={GridRef}
-                    columnCount={5}
-                    columnWidth={i => (listWidth - 20) / 5}
+                    columnCount={getColumnCount(windowSize.width)}
+                    columnWidth={i =>
+                      (listWidth - 20) / getColumnCount(windowSize.width)
+                    }
                     height={listHeight}
                     rowCount={Math.floor(levelpacksSorted.length / 5) + 1}
                     rowHeight={i => 100}

--- a/src/pages/levels/store.js
+++ b/src/pages/levels/store.js
@@ -108,7 +108,7 @@ export default {
     if (get.ok) {
       const indexed = get.data.reduce((acc, val) => {
         val.NormalizedPopularity = shiftedLogisticFn(
-          0.968,
+          0.9935,
           val.AvgKuskiPerLevel,
         );
 

--- a/src/react-query.js
+++ b/src/react-query.js
@@ -1,5 +1,8 @@
 import { QueryClient } from 'react-query';
 
 export const queryClient = new QueryClient({
-  defaultOptions: {},
+  defaultOptions: {
+    // in ms
+    staleTime: 300000,
+  },
 });

--- a/src/router.js
+++ b/src/router.js
@@ -66,6 +66,12 @@ const Routes = () => {
           <Help path="help/*" />
           <Kuski path="kuskis/:name" tab="" />
           <Kuski path="kuskis/:name/:tab" />
+          <Kuski
+            path="kuskis/:name/records"
+            tab="records"
+            recordSort="TimeAll"
+          />
+          <Kuski path="kuskis/:name/records/:recordSort" tab="records" />
           <Kuskis path="kuskis" tab="" />
           <Kuskis path="kuskis/search" tab="search" />
           <Level path="levels/:LevelId" />


### PR DESCRIPTION
- levelpack archive works on mobile
- adjusted formula for levelpack archive popularity bar to reflect production database
- levelpack archive detailed view works better on mobile (and no longer lists more than 2 top kuski's)
- home page recent records has more clear title and re-worked columns.
- player records page has attempts column added, and sort by time (high/low) options.
- sort option for player records page stored in URL instead of component state.