### PR TITLE
feat(levelpack): crippled best times and personal records

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -41,6 +41,12 @@ export const useQueryAlt = (
   queryOpts = {},
   arrayFormat = false,
 ) => {
+  // I thought this should be added to defaultOptions (src/react-query.js),
+  // but this didn't stop queries from re-fetching when using navigate.
+  if (queryOpts.staleTime === undefined) {
+    queryOpts.staleTime = 300000;
+  }
+
   return useQuery(
     queryKey,
     async (...args) => {
@@ -51,14 +57,14 @@ export const useQueryAlt = (
       if (arrayFormat) {
         assert(
           isArray(res) && res.length === 2,
-          'Expected an async queryFn resolved to an array of length 2.',
+          'Expected an async queryFn that resolves to an array of length 2.',
         );
 
         [ok, data] = res;
       } else {
         assert(
           isObjectLike(res),
-          'Expected an async queryFn that resolved to an object.',
+          'Expected an async queryFn that resolves to an object.',
         );
 
         ok = res.ok;
@@ -209,6 +215,12 @@ export const CrippledPersonal = (LevelIndex, KuskiIndex = 0, cripple, limit) =>
 export const CrippledTimeStats = (LevelIndex, KuskiIndex = 0, cripple) =>
   api.get(`crippled/timeStats/${LevelIndex}/${KuskiIndex}/${cripple}`);
 
+export const CrippledLevelPackRecords = (LevelPackName, cripple) =>
+  api.get(`crippled/levelPackRecords/${LevelPackName}/${cripple}`);
+
+export const CrippledLevelPackPersonalRecords = (LevelPackName, KuskiIndex) =>
+  api.get(`crippled/levelPackPersonalRecords/${LevelPackName}/${KuskiIndex}`);
+
 // levelpack
 export const LevelPacks = () => api.get('levelpack');
 export const LevelPacksStats = () => api.get('levelpack/stats');
@@ -251,8 +263,11 @@ export const LevelPackLevelStats = async (byName, NameOrIndex) => {
 
   return ret;
 };
+export const LevelPack = (LevelPackName, levels = 0) =>
+  api.get(`levelpack/${LevelPackName}`, {
+    levels: levels ? '1' : undefined,
+  });
 
-export const LevelPack = LevelPackName => api.get(`levelpack/${LevelPackName}`);
 export const TotalTimes = data =>
   api.get(`levelpack/${data.levelPackIndex}/totaltimes/${data.eolOnly}`);
 export const PersonalTimes = data =>

--- a/src/components/Kuski.js
+++ b/src/components/Kuski.js
@@ -20,7 +20,7 @@ const Kuski = ({ kuskiData, team, flag, noLink }) => (
             {kuskiData.Kuski && kuskiData.Kuski}
           </Link>
         )}
-        {team && kuskiData.TeamData && (
+        {team && kuskiData?.TeamData?.Team && (
           <>
             {' '}
             {noLink ? (

--- a/src/pages/levelpack/Crippled.js
+++ b/src/pages/levelpack/Crippled.js
@@ -1,0 +1,302 @@
+import React from 'react';
+import { useStoreState } from 'easy-peasy';
+import styled from 'styled-components';
+import { useNavigate } from '@reach/router';
+import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
+import { ListCell, ListContainer, ListHeader, ListRow } from 'components/List';
+import Kuski from 'components/Kuski';
+import Time from 'components/Time';
+import { Level } from 'components/Names';
+import Loading from 'components/Loading';
+import { parsedTimeToString, parseTimeHundreds } from 'utils/recTime';
+import {
+  CrippledLevelPackRecords,
+  CrippledLevelPackPersonalRecords,
+  useQueryAlt,
+} from 'api';
+import { toLocalTime } from 'utils/time';
+
+const cripples = [
+  'noVolt',
+  'noTurn',
+  'oneTurn',
+  'noBrake',
+  'noThrottle',
+  'alwaysThrottle',
+  'oneWheel',
+  'drunk',
+];
+
+const NotFinished = () => {
+  return <span title="Not finished">--</span>;
+};
+
+const shouldHighlight = (record, highlightUnix) => {
+  return (
+    highlightUnix &&
+    highlightUnix > 0 &&
+    record &&
+    record.Driven >= highlightUnix
+  );
+};
+
+const recordDate = record => {
+  if (record && record.Driven) {
+    return toLocalTime(record.Driven, 'X').format('ddd D MMM YYYY HH:mm');
+  }
+
+  return '';
+};
+
+const PersonalTable = ({ levels, personalRecords, highlightUnix }) => {
+  return (
+    <ListContainer>
+      <ListHeader>
+        <ListCell width={100}>Filename</ListCell>
+        <ListCell width={180}>Level Name</ListCell>
+        <ListCell>No Volt</ListCell>
+        <ListCell>No Turn</ListCell>
+        <ListCell>One Turn</ListCell>
+        <ListCell>No Brake</ListCell>
+        <ListCell>No Throttle</ListCell>
+        <ListCell>Always Throttle</ListCell>
+        <ListCell>One Wheel</ListCell>
+        <ListCell>Drunk</ListCell>
+      </ListHeader>
+      {levels.map(level => {
+        return (
+          <ListRow key={level.LevelIndex}>
+            <ListCell>
+              <Level LevelIndex={level.LevelIndex} LevelData={level} />
+            </ListCell>
+            <ListCell>
+              <span>{level.LongName}</span>
+            </ListCell>
+            {cripples.map(cripple => {
+              const personalRecord =
+                personalRecords?.[level.LevelIndex]?.[cripple];
+
+              return (
+                <ListCell
+                  highlight={shouldHighlight(personalRecord, highlightUnix)}
+                  title={recordDate(personalRecord)}
+                >
+                  {personalRecord && <Time time={personalRecord.Time} />}
+                  {!personalRecord && <NotFinished />}
+                </ListCell>
+              );
+            })}
+          </ListRow>
+        );
+      })}
+    </ListContainer>
+  );
+};
+
+const CrippledTypeTable = ({
+  levels,
+  records,
+  personalRecords,
+  crippleType,
+  showPersonal,
+  highlightUnix,
+}) => {
+  return (
+    <ListContainer>
+      <ListHeader>
+        <ListCell width={100}>Filename</ListCell>
+        <ListCell width={320}>Level Name</ListCell>
+        <ListCell width={200}>Kuski</ListCell>
+        <ListCell width={130}>Time</ListCell>
+        <ListCell>{showPersonal && 'Personal'}</ListCell>
+        <ListCell />
+      </ListHeader>
+
+      {levels.map(level => {
+        const record = records?.[level.LevelIndex];
+
+        const personalRecord =
+          personalRecords?.[level.LevelIndex]?.[crippleType];
+
+        const personalIsRecord =
+          (record &&
+            personalRecord &&
+            record.TimeIndex === personalRecord.TimeIndex) ||
+          false;
+
+        const diff =
+          (record && personalRecord && personalRecord.Time - record.Time) || 0;
+
+        return (
+          <ListRow key={level.LevelIndex}>
+            <ListCell>
+              <Level LevelIndex={level.LevelIndex} LevelData={level} />
+            </ListCell>
+            <ListCell>
+              <span>{level.LongName}</span>
+            </ListCell>
+            <ListCell>
+              {record !== undefined && (
+                <Kuski kuskiData={record.KuskiData} flag={true} team={true} />
+              )}
+            </ListCell>
+            <ListCell
+              highlight={shouldHighlight(record, highlightUnix)}
+              title={recordDate(record)}
+            >
+              {record && <Time time={record.Time} />}
+              {!record && <NotFinished />}
+            </ListCell>
+            <ListCell
+              highlight={shouldHighlight(personalRecord, highlightUnix)}
+              title={personalIsRecord ? '' : recordDate(personalRecord)}
+            >
+              {showPersonal && personalRecord === undefined && <NotFinished />}
+              {showPersonal && personalRecord && personalIsRecord && (
+                <span>Record</span>
+              )}
+              {showPersonal && personalRecord && !personalIsRecord && (
+                <>
+                  <Time time={personalRecord.Time} />
+                  {diff > 0 && (
+                    <TimeDiff>
+                      {' '}
+                      (+{parsedTimeToString(parseTimeHundreds(diff))})
+                    </TimeDiff>
+                  )}
+                </>
+              )}
+            </ListCell>
+            <ListCell />
+          </ListRow>
+        );
+      })}
+    </ListContainer>
+  );
+};
+
+const Crippled = ({ LevelPack, crippleType, highlightWeeks }) => {
+  const navigate = useNavigate();
+
+  const levels = Array.isArray(LevelPack.levels) ? LevelPack.levels : [];
+
+  const highlightUnix =
+    Math.floor(new Date().getTime() / 1000) - highlightWeeks * 3600 * 24 * 7;
+
+  let { userid } = useStoreState(state => state.Login);
+  userid = +userid;
+
+  const { data: records = {}, ...recordsRequest } = useQueryAlt(
+    ['CrippledLevelPackRecords', LevelPack.LevelPackName, crippleType],
+    async () => CrippledLevelPackRecords(LevelPack.LevelPackName, crippleType),
+    {
+      enabled: !!(
+        crippleType &&
+        crippleType !== 'all-personal' &&
+        LevelPack?.LevelPackName
+      ),
+    },
+  );
+
+  const { data: personalRecords = {} } = useQueryAlt(
+    ['CrippledLevelPackPersonalRecords', LevelPack.LevelPackName, userid],
+    async () =>
+      CrippledLevelPackPersonalRecords(LevelPack.LevelPackName, userid),
+    {
+      enabled: !!(userid && LevelPack?.LevelPackName),
+    },
+  );
+
+  return (
+    <Root>
+      <Controls>
+        <CrippleSelect>
+          <InputLabel id="cripple">Cripple</InputLabel>
+          <Select
+            id="cripple"
+            value={crippleType}
+            onChange={e => {
+              navigate(
+                [
+                  '/levels/packs',
+                  LevelPack.LevelPackName,
+                  'crippled',
+                  e.target.value,
+                ]
+                  .filter(Boolean)
+                  .join('/'),
+              );
+            }}
+          >
+            <MenuItem value="noVolt">No Volt</MenuItem>
+            <MenuItem value="noTurn">No Turn</MenuItem>
+            <MenuItem value="oneTurn">One Turn</MenuItem>
+            <MenuItem value="noBrake">No Brake</MenuItem>
+            <MenuItem value="noThrottle">No Throttle</MenuItem>
+            <MenuItem value="alwaysThrottle">Always Throttle</MenuItem>
+            <MenuItem value="oneWheel">One Wheel</MenuItem>
+            <MenuItem value="drunk">Drunk</MenuItem>
+            {userid && (
+              <MenuItem value="all-personal">All Types (Personal)</MenuItem>
+            )}
+          </Select>
+        </CrippleSelect>
+      </Controls>
+
+      {!crippleType && 'Select a cripple type.'}
+
+      {recordsRequest.isLoading && <Loading />}
+      {recordsRequest.isError && <span>Error.</span>}
+
+      {crippleType === 'all-personal' && (
+        <PersonalTable
+          levels={levels}
+          records={records}
+          personalRecords={personalRecords}
+          highlightUnix={highlightUnix}
+        />
+      )}
+
+      {crippleType && crippleType !== 'all-personal' && (
+        <CrippledTypeTable
+          levels={levels}
+          records={records}
+          personalRecords={personalRecords}
+          crippleType={crippleType}
+          showPersonal={userid > 0}
+          highlightUnix={highlightUnix}
+        />
+      )}
+    </Root>
+  );
+};
+
+const Root = styled.div`
+  padding-bottom: 50px;
+`;
+
+const Controls = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  padding-right: 16px;
+  padding-bottom: 25px;
+  && {
+    > * {
+      margin-right: 18px;
+      &:last-child {
+        margin-right: 0;
+      }
+    }
+  }
+`;
+
+const CrippleSelect = styled(FormControl)`
+  min-width: 175px !important;
+`;
+
+const TimeDiff = styled.span`
+  color: ${p => p.theme.errorColor};
+`;
+
+export default Crippled;

--- a/src/pages/levelpack/index.js
+++ b/src/pages/levelpack/index.js
@@ -29,11 +29,13 @@ import TotalTimes from './TotalTimes';
 import Personal from './Personal';
 import Kinglist from './Kinglist';
 import MultiRecords from './MultiRecords';
+import Crippled from './Crippled';
 import Admin from './Admin';
 import { useQueryAlt, LevelPackLevelStats } from '../../api';
 
-const LevelPack = ({ name, tab }) => {
+const LevelPack = ({ name, tab, ...props }) => {
   const isRehydrated = useStoreRehydrated();
+  const subTab = props['*'];
   const {
     levelPackInfo,
     highlight,
@@ -45,6 +47,7 @@ const LevelPack = ({ name, tab }) => {
     personalKuski,
     settings: { highlightWeeks, showLegacyIcon, showLegacy, showMoreStats },
   } = useStoreState(state => state.LevelPack);
+
   const {
     getLevelPackInfo,
     getHighlight,
@@ -110,9 +113,15 @@ const LevelPack = ({ name, tab }) => {
           variant="scrollable"
           scrollButtons="auto"
           value={tab}
-          onChange={(e, value) =>
-            navigate(['/levels/packs', name, value].filter(Boolean).join('/'))
-          }
+          onChange={(e, value) => {
+            if (value === 'crippled') {
+              navigate(['/levels/packs', name, 'crippled/noVolt'].join('/'));
+            } else {
+              navigate(
+                ['/levels/packs', name, value].filter(Boolean).join('/'),
+              );
+            }
+          }}
         >
           <Tab label="Records" value="" />
           <Tab label="Total Times" value="total-times" />
@@ -120,6 +129,7 @@ const LevelPack = ({ name, tab }) => {
           <Tab label="Personal" value="personal" />
           <Tab label="Multi records" value="multi" />
           <Tab label="Replays" value="replays" />
+          <Tab label="Crippled" value="crippled" />
           {adminAuth && <Tab label="Admin" value="admin" />}
         </Tabs>
         <LevelPackName>
@@ -262,11 +272,18 @@ const LevelPack = ({ name, tab }) => {
             highlightWeeks={highlightWeeks}
           />
         )}
-        {tab === 'admin' && adminAuth && (
-          <Admin records={records} LevelPack={levelPackInfo} />
+        {tab === 'crippled' && (
+          <Crippled
+            LevelPack={levelPackInfo}
+            crippleType={subTab}
+            highlightWeeks={highlightWeeks}
+          />
         )}
         {tab === 'replays' && (
           <ReplayList nonsticky levelPack={levelPackInfo.LevelPackIndex} />
+        )}
+        {tab === 'admin' && adminAuth && (
+          <Admin records={records} LevelPack={levelPackInfo} />
         )}
       </RootStyle>
     </Layout>

--- a/src/pages/levelpack/store.js
+++ b/src/pages/levelpack/store.js
@@ -23,7 +23,7 @@ export default {
     state.levelPackInfo = payload;
   }),
   getLevelPackInfo: thunk(async (actions, payload) => {
-    const get = await LevelPack(payload);
+    const get = await LevelPack(payload, true);
     if (get.ok) {
       actions.setLevelPackInfo(get.data);
     }

--- a/src/react-query.js
+++ b/src/react-query.js
@@ -2,7 +2,7 @@ import { QueryClient } from 'react-query';
 
 export const queryClient = new QueryClient({
   defaultOptions: {
-    // in ms
-    staleTime: 300000,
+    // I think necessary to not trigger re-fetch when using navigate:
+    refetchOnMount: false,
   },
 });

--- a/src/router.js
+++ b/src/router.js
@@ -76,7 +76,7 @@ const Routes = () => {
           <Kuskis path="kuskis/search" tab="search" />
           <Level path="levels/:LevelId" />
           <LevelPack path="levels/packs/:name" tab="" />
-          <LevelPack path="levels/packs/:name/:tab" />
+          <LevelPack path="levels/packs/:name/:tab/*" />
           <Levels path="levels" tab="" />
           {/* can't use levels/:tab due to conflict with levels/:LevelId above*/}
           <Levels path="levels/collections" tab="collections" />


### PR DESCRIPTION
replaces this:

https://github.com/elmadev/elmaonline-web/pull/85

The main thing is that we no longer load all top 10's from all crippled types for an entire level pack. Now it's only 1 cripple type at a time, and only the top time. I also finished up highlighting recent times.

Performance is too all over the place with not enough ram and big tables being read from disk and stuff. This doesn't allow as many features as I initially wanted, but its a lot safer/faster and good enough.