### PR TITLE
feat(levelpack): records tab shows levels before records are loaded. …

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -280,6 +280,8 @@ export const PersonalWithMulti = data =>
   );
 export const LevelPackStats = data =>
   api.get(`levelpack/${data.name}/stats/${data.eolOnly}`);
+export const LevelPackRecords = (LevelPackName, eolOnly) =>
+  api.get(`levelpack/${LevelPackName}/records/${eolOnly ? 1 : 0}`);
 export const MultiRecords = LevelPackName =>
   api.get(`levelpack/${LevelPackName}/multirecords`);
 export const LevelPackSearch = q => api.get(`levelpack/search/${q}`);

--- a/src/pages/levelpack/index.js
+++ b/src/pages/levelpack/index.js
@@ -38,12 +38,11 @@ const LevelPack = ({ name, tab, ...props }) => {
   const subTab = props['*'];
   const {
     levelPackInfo,
+    records,
     highlight,
     multiHighlight,
     personalTimes,
     timesError,
-    records,
-    recordsLoading,
     personalKuski,
     settings: { highlightWeeks, showLegacyIcon, showLegacy, showMoreStats },
   } = useStoreState(state => state.LevelPack);
@@ -204,7 +203,7 @@ const LevelPack = ({ name, tab, ...props }) => {
                     </RadioButtonItem>
                   </RadioButtonContainer>
                 </FormControl>
-                {levelPackInfo.Legacy === 1 && (
+                {levelPackInfo?.Legacy === 1 && (
                   <>
                     <SettingItem>
                       <FieldBoolean
@@ -230,11 +229,13 @@ const LevelPack = ({ name, tab, ...props }) => {
         </Settings>
         {!tab && (
           <Records
+            levelPackInfo={
+              levelPackInfo?.LevelPackName === name ? levelPackInfo : null
+            }
             levelStats={levelStats}
-            records={records}
+            showLegacy={showLegacy}
             highlight={highlight}
             highlightWeeks={highlightWeeks}
-            recordsLoading={recordsLoading}
             showLegacyIcon={showLegacyIcon}
             showMoreStats={showMoreStats}
           />


### PR DESCRIPTION
…records uses optimized endpoint.

The records tab for levelpacks (ie. elma.online/levels/packs/Int) shows the levels as soon as they are loaded, which is very fast. Then it shows the records when those are done loading. The records also use a faster endpoint than they used to, since the old endpoint calculated total times, king list, and records all at once. It's much less work to calculate only the records. In dev it was about 3x faster.

A few caveats:
- The previous endpoint for records, total times, and king list (which is a very expensive query, and can take over 10s for internals), still runs on the records tab even though its not needed. I gave this a lot of time and effort but there's just no solution that I can come up without adding more complexity than is already there already is or doing a big re-factor. Note: this means by the time someone clicks king list or total times, the data might already be there. So it's not totally a bad thing. But as records is the default tab for level packs, it's not great from the server's perspective to get this data when its not displayed most of the time.
- when using admin tab, records tab won't update automatically any more without a page reload. I feel like it shouldn't be a huge issue. 
