### PR TITLE
fix(search): fix broken level search when there is no AddedBy info

### DIFF
--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -213,14 +213,16 @@ const Search = () => {
                               parse="X"
                             />
                           </ListCell>
-                          <ListCell
-                            width={90}
-                            to={`/kuskis/${r.KuskiData.Kuski}`}
-                          >
-                            {r.KuskiData && (
+                          {r.KuskiData ? (
+                            <ListCell
+                              width={90}
+                              to={`/kuskis/${r.KuskiData.Kuski}`}
+                            >
                               <Kuski noLink kuskiData={r.KuskiData} />
-                            )}
-                          </ListCell>
+                            </ListCell>
+                          ) : (
+                            <ListCell width={90}>{'Unknown'}</ListCell>
+                          )}
                           {mod() === 1 && showLocked && (
                             <>
                               <ListCell width={50}>


### PR DESCRIPTION
AddedBy is 0 for a small number of levels with no runs.