### PR TITLE
fix(levelpacks): fix swapped dead and esced labels

### DIFF
--- a/src/pages/kuski/Preview.js
+++ b/src/pages/kuski/Preview.js
@@ -12,13 +12,13 @@ import styled from 'styled-components';
 import NavigateNextIcon from '@material-ui/icons/NavigateNext';
 import NavigateBeforeIcon from '@material-ui/icons/NavigateBefore';
 
-const Finished = {
-  F: 'Finished',
-  D: 'Died',
+const finishedTypes = {
+  B: 'Finished (Apple Bug)',
+  D: 'Dead',
   E: 'Escaped',
-  X: 'Cheated',
+  F: 'Finished',
   S: 'Spied',
-  B: 'Apple Bugged',
+  X: 'Cheated',
 };
 
 export default function Preview({
@@ -65,7 +65,7 @@ export default function Preview({
               </p>
               {has(previewRec, 'Apples') && (
                 <Comment>
-                  {Finished[previewRec.Finished]}
+                  {finishedTypes[previewRec.Finished]}
                   <br />
                   {previewRec.Apples} Apples
                   <br />

--- a/src/pages/level/LevelInfoLevelStats.js
+++ b/src/pages/level/LevelInfoLevelStats.js
@@ -23,7 +23,7 @@ const LevelInfoLevelStats = ({ level }) => {
           <ListCell>Type</ListCell>
           <ListCell>Finished %</ListCell>
           <ListCell>Dead %</ListCell>
-          <ListCell>Escape %</ListCell>
+          <ListCell>Escaped %</ListCell>
           <ListCell>Total</ListCell>
         </ListHeader>
         <ListRow>
@@ -40,11 +40,11 @@ const LevelInfoLevelStats = ({ level }) => {
           <ListCell title={formatAttempts(stats.AttemptsF)}>
             {formatPct(stats.AttemptsF, stats.AttemptsAll, 1)}
           </ListCell>
-          <ListCell title={formatAttempts(stats.AttemptsE)}>
-            {formatPct(stats.AttemptsE, stats.AttemptsAll, 1)}
-          </ListCell>
           <ListCell title={formatAttempts(stats.AttemptsD)}>
             {formatPct(stats.AttemptsD, stats.AttemptsAll, 1)}
+          </ListCell>
+          <ListCell title={formatAttempts(stats.AttemptsE)}>
+            {formatPct(stats.AttemptsE, stats.AttemptsAll, 1)}
           </ListCell>
           <ListCell>{formatAttempts(stats.AttemptsAll)}</ListCell>
         </ListRow>
@@ -53,11 +53,11 @@ const LevelInfoLevelStats = ({ level }) => {
           <ListCell title={formatTimeSpent(stats.TimeF)}>
             {formatPct(stats.TimeF, stats.TimeAll, 1)}
           </ListCell>
-          <ListCell title={formatTimeSpent(stats.TimeE)}>
-            {formatPct(stats.TimeE, stats.TimeAll, 1)}
-          </ListCell>
           <ListCell title={formatTimeSpent(stats.TimeD)}>
             {formatPct(stats.TimeD, stats.TimeAll, 1)}
+          </ListCell>
+          <ListCell title={formatTimeSpent(stats.TimeE)}>
+            {formatPct(stats.TimeE, stats.TimeAll, 1)}
           </ListCell>
           <ListCell>{formatTimeSpent(stats.TimeAll)}</ListCell>
         </ListRow>

--- a/src/pages/level/StatsTable.js
+++ b/src/pages/level/StatsTable.js
@@ -10,7 +10,7 @@ import styled from 'styled-components';
 const finishedTypes = {
   B: 'Finished (Apple Bug)',
   D: 'Dead',
-  E: 'Esced',
+  E: 'Escaped',
   F: 'Finished',
   S: 'Spied',
   X: 'Cheated',

--- a/src/pages/levels/Controls.js
+++ b/src/pages/levels/Controls.js
@@ -57,12 +57,12 @@ const Controls = ({ detailed, sort }) => {
             <MenuItem value="topKuskiCount">
               Highest Record Holder Count
             </MenuItem>
-            <MenuItem value="attemptsPctD">Attempts % (Dead)</MenuItem>
-            <MenuItem value="attemptsPctE">Attempts % (Esc)</MenuItem>
             <MenuItem value="attemptsPctF">Attempts % (Finished)</MenuItem>
-            <MenuItem value="timePctD">Time % (Dead)</MenuItem>
-            <MenuItem value="timePctE">Time % (Esc)</MenuItem>
+            <MenuItem value="attemptsPctD">Attempts % (Dead)</MenuItem>
+            <MenuItem value="attemptsPctE">Attempts % (Escaped)</MenuItem>
             <MenuItem value="timePctF">Time % (Finished)</MenuItem>
+            <MenuItem value="timePctD">Time % (Dead)</MenuItem>
+            <MenuItem value="timePctE">Time % (Escaped)</MenuItem>
             <MenuItem value="minTime">Min Record Time</MenuItem>
             <MenuItem value="maxTime">Max Record Time</MenuItem>
             <MenuItem value="avgTime">Avg. Record Time</MenuItem>

--- a/src/pages/levels/LevelpacksDetailed.js
+++ b/src/pages/levels/LevelpacksDetailed.js
@@ -36,7 +36,7 @@ const LevelpacksDetailed = ({
           <ListCell>
             <NewLineWrapper>Attempts %</NewLineWrapper>
             <NewLineWrapper>Time %</NewLineWrapper>
-            <NewLineWrapper>(Dead/Esc/Finished)</NewLineWrapper>
+            <NewLineWrapper>(Finished/Dead/Escaped)</NewLineWrapper>
           </ListCell>
           <ListCell>
             <NewLineWrapper># Levels (% Finished)</NewLineWrapper>
@@ -92,15 +92,15 @@ const LevelpacksDetailed = ({
                   {st &&
                     (() => {
                       const timesPct = [
+                        ['F', formatPct(st.TimeF, st.TimeAll)],
                         ['D', formatPct(st.TimeD, st.TimeAll)],
                         ['E', formatPct(st.TimeE, st.TimeAll)],
-                        ['F', formatPct(st.TimeF, st.TimeAll)],
                       ];
 
                       const attemptsPct = [
+                        ['F', formatPct(st.AttemptsF, st.AttemptsAll)],
                         ['D', formatPct(st.AttemptsD, st.AttemptsAll)],
                         ['E', formatPct(st.AttemptsE, st.AttemptsAll)],
-                        ['F', formatPct(st.AttemptsF, st.AttemptsAll)],
                       ];
 
                       return (


### PR DESCRIPTION
Also make the finish type labels and ordering more consistent across pages.

Fixes https://github.com/elmadev/elmaonline-site/issues/566