### PR TITLE
Fixed Game link & Updated links to open in New Tab

### DIFF
--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -14,12 +14,12 @@ const Welcome = () => {
           multiplay and watching others. To get started:
           <List>
             <li>
-              <a href="https://store.steampowered.com/app/1290220/Elasto_Mania/">
+              <a href="https://store.steampowered.com/app/1290220/Elasto_Mania_Remastered/" target="_blank" rel="noreferrer">
                 Buy Elasto Mania on steam
               </a>
             </li>
             <li>
-              <a href="https://steamcommunity.com/workshop/filedetails/?id=2094059600">
+              <a href="https://steamcommunity.com/workshop/filedetails/?id=2094059600" target="_blank" rel="noreferrer">
                 Install the Elma Online mod on steam workshop
               </a>
             </li>

--- a/src/pages/help/tabs/HowToInstall.js
+++ b/src/pages/help/tabs/HowToInstall.js
@@ -9,10 +9,10 @@ const HowToInstall = () => {
       <Header h3>Buying Elasto Mania</Header>
       <List>
         <li>
-          <a href="https://store.steampowered.com/about/">Install steam</a>
+          <a href="https://store.steampowered.com/about/" target="_blank" rel="noreferrer">Install steam</a>
         </li>
         <li>
-          <a href="https://store.steampowered.com/app/1290220/Elasto_Mania/">
+          <a href="https://store.steampowered.com/app/1290220/Elasto_Mania_Remastered/" target="_blank" rel="noreferrer">
             Buy Elasto Mania on steam
           </a>
         </li>
@@ -21,7 +21,7 @@ const HowToInstall = () => {
       <Header h3>Upgrading to Elma Online</Header>
       <List>
         <li>
-          <a href="https://steamcommunity.com/workshop/filedetails/?id=2094059600">
+          <a href="https://steamcommunity.com/workshop/filedetails/?id=2094059600" target="_blank" rel="noreferrer">
             Install the Elma Online mod on steam workshop by clicking subscribe
           </a>
         </li>
@@ -29,7 +29,7 @@ const HowToInstall = () => {
       </List>
       <Header h3>Issues</Header>
       If you run into issues you can ask someone in{' '}
-      <a href="https://discord.gg/j5WMFC6">discord</a> who&apos;ll usually have
+      <a href="https://discord.gg/j5WMFC6" target="_blank" rel="noreferrer">discord</a> who&apos;ll usually have
       a solution. Tag @eolmod for a faster response.
     </Text>
   );


### PR DESCRIPTION
- Updated the Game link, since Game name has changed from **Elasto Mania** to **Elasto Mania Remastered** (_appid_ is same)
- Added `target="_blank"` and `rel="noreferrer"` to those _anchor tags_ so they **Open in New Tab**