### PR TITLE
fix(cup): team tab loads events when navigating directly to it

### DIFF
--- a/src/pages/cup/Team.js
+++ b/src/pages/cup/Team.js
@@ -33,8 +33,10 @@ const Team = () => {
   const [previewRecIndex, setPreviewRecIndex] = useState(null);
 
   useEffect(() => {
-    getTeamReplays(cup.CupGroupIndex);
-  }, []);
+    if (cup.CupGroupIndex) {
+      getTeamReplays(cup.CupGroupIndex);
+    }
+  }, [cup.CupGroupIndex]);
 
   const isPlayingPreview = CupTimeIndex => {
     return CupTimeIndex === previewRecIndex;


### PR DESCRIPTION
used to only work when you started on another tab, because it would fetch the cup object in some other request. Now if you refresh the page or click on a link directly to the tab, the events and replays will properly get loaded.