### PR TITLE
Add device settings tab and replay viewer default zoom scale

### DIFF
--- a/src/components/Recplayer.js
+++ b/src/components/Recplayer.js
@@ -16,7 +16,7 @@ const Recplayer = props => {
     merge,
   } = props;
   const {
-    settings: { grass, pictures, customSkyGround },
+    settings: { grass, pictures, customSkyGround, zoomScale },
   } = useStoreState(state => state.ReplaySettings);
 
   let defaultZoom = 1;
@@ -31,6 +31,10 @@ const Recplayer = props => {
 
   if (useMediaQuery('(max-width: 500px)')) {
     defaultZoom = 0.58;
+  }
+
+  if (zoomScale && zoomScale > 0) {
+    defaultZoom = defaultZoom * (zoomScale / 100);
   }
 
   const zoom = props.zoom || defaultZoom;

--- a/src/features/ReplaySettings/store.js
+++ b/src/features/ReplaySettings/store.js
@@ -10,10 +10,15 @@ export default {
       pictures: true,
       customSkyGround: true,
       theater: false,
+      // scaling (%) for default zoom on page load
+      zoomScale: 100,
     },
     { storage: 'localStorage' },
   ),
   toggleSetting: action((state, payload) => {
     state.settings[payload] = !state.settings[payload];
+  }),
+  setZoomScale: action((state, payload) => {
+    state.settings.zoomScale = parseInt(payload, 10);
   }),
 };

--- a/src/pages/settings/DeviceSettings.js
+++ b/src/pages/settings/DeviceSettings.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { useStoreState, useStoreActions } from 'easy-peasy';
+import { Column } from 'components/Containers';
+import { Grid } from '@material-ui/core';
+import { Paper } from 'components/Paper';
+import { TextField } from '@material-ui/core';
+
+const SetZoomScale = () => {
+  const { zoomScale } = useStoreState(
+    actions => actions.ReplaySettings.settings,
+  );
+  const { setZoomScale } = useStoreActions(actions => actions.ReplaySettings);
+
+  return (
+    <TextField
+      type="number"
+      label="Replay Viewer Scale %"
+      value={zoomScale}
+      onChange={e => setZoomScale(e.target.value)}
+      margin="normal"
+      variant="outlined"
+      fullWidth
+    />
+  );
+};
+
+const DeviceSettings = () => {
+  return (
+    <Grid container spacing={2}>
+      <Grid item sm={6} xs={12}>
+        <Paper padding width="auto">
+          <Column>
+            <SetZoomScale />
+          </Column>
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default DeviceSettings;

--- a/src/pages/settings/index.js
+++ b/src/pages/settings/index.js
@@ -13,6 +13,7 @@ import Setting from './Setting';
 import Themes from './Themes';
 import Notifications from './Notifications';
 import { useNavigate } from '@reach/router';
+import DeviceSettings from './DeviceSettings';
 
 const Settings = ({ tab }) => {
   const { userInfo, error, message, ignored } = useStoreState(
@@ -76,11 +77,12 @@ const Settings = ({ tab }) => {
           navigate(['/settings', value].filter(Boolean).join('/'));
         }}
       >
-        <Tab label="User info" value="" />
-        <Tab label="Team" value="team" />
-        <Tab label="Ignore" value="ignore" />
-        <Tab label="Site theme" value="themes" />
-        <Tab label="Notifications" value="notifications" />
+        {nickId() > 0 && <Tab label="User info" value="" />}
+        {nickId() > 0 && <Tab label="Team" value="team" />}
+        {nickId() > 0 && <Tab label="Ignore" value="ignore" />}
+        {nickId() > 0 && <Tab label="Site theme" value="themes" />}
+        {nickId() > 0 && <Tab label="Notifications" value="notifications" />}
+        <Tab label="Device Settings" value="device" />
       </Tabs>
       <Container>
         {nickId() > 0 ? (
@@ -200,8 +202,10 @@ const Settings = ({ tab }) => {
             {tab === 'notifications' && <Notifications />}
           </>
         ) : (
-          <div>Log in to change settings.</div>
+          <>{tab !== 'device' && <div>Log in to change settings.</div>}</>
         )}
+        {tab === 'device' && <DeviceSettings />}
+
         <Feedback
           open={error !== ''}
           text={error}

--- a/src/pages/settings/store.js
+++ b/src/pages/settings/store.js
@@ -112,4 +112,13 @@ export default {
       actions.getSettings();
     }
   }),
+  defaultZoom: persist(
+    {
+      scale: 100,
+    },
+    { storage: 'localStorage' },
+  ),
+  setDefaultZoom: action((state, scale) => {
+    state.defaultZoom.scale = parseInt(scale, 10);
+  }),
 };


### PR DESCRIPTION
Since there are some different recplayers across the site, and not all have settings icon underneath them, I added a new tab for device settings, which can be viewed when not logged in. It has the single setting for now to adjust the scale of the recplayer zoom on page load. So you can set it to 50% for example to be twice as zoomed out as normal when the page loads with a replay in it. I added this because I feel like I prefer battle recs to be more zoomed on mobile, but it's not easy to choose one number that suits all.

In the future we could add the zoom scale input to the RecplaySettings component, and then add the settings component to the different recplayer instances.

Also, people not logged in will have a hard time finding this setting. We could maybe add a Settings icon next to "Login" which links to the Device Settings tab. But if we update RecplayerSettings instead than that might not be necessary.