### PR TITLE
Add back recent top records card (as a sub page of levels this time)

### DIFF
--- a/src/components/RecentRecords.js
+++ b/src/components/RecentRecords.js
@@ -1,28 +1,33 @@
 import React from 'react';
+import styled from 'styled-components';
 import { ListContainer, ListHeader, ListRow, ListCell } from 'components/List';
 import Link from 'components/Link';
 import Time from 'components/Time';
 import Kuski from 'components/Kuski';
 import formatDistance from 'date-fns/formatDistance';
-import { formatTimeSpent } from 'utils/format';
+import { formatTimeSpent, formatAttempts } from 'utils/format';
 
 const RecentRecords = ({ records }) => {
   return (
-    <>
+    <Root>
       <ListContainer>
         <ListHeader>
           <ListCell>Kuski</ListCell>
+          <ListCell>Level</ListCell>
           <ListCell>Time</ListCell>
-          <ListCell title="Level and cumulative playtime on level by all Kuski's">
-            Level
+          <ListCell title="The current standing of the time driven. 1 means record.">
+            Standing
           </ListCell>
           <ListCell>Driven</ListCell>
+          <ListCell>Kuski's Played</ListCell>
+          <ListCell>Playtime (All Kuski's)</ListCell>
+          <ListCell>Attempts (All Kuski's)</ListCell>
         </ListHeader>
         {Array.isArray(records) &&
           records.map(r => {
             const level = r.LevelData || {};
             const kuski = r.KuskiData || {};
-            const levUrl = `levels/${level.LevelIndex}`;
+            const levUrl = `/levels/${level.LevelIndex}`;
             const driven2 = formatDistance(
               new Date(r.Driven * 1000),
               new Date(),
@@ -30,26 +35,34 @@ const RecentRecords = ({ records }) => {
             );
 
             return (
-              <ListRow>
+              <ListRow key={[r.KuskiIndex, r.Driven].join('-')}>
                 <ListCell>
                   <Kuski kuskiData={kuski} flag={true} team={true} />
-                </ListCell>
-                <ListCell>
-                  <Time time={r.Time} />
                 </ListCell>
                 <ListCell>
                   <Link to={levUrl} title={level.LongName}>
                     {level.LevelName}
                   </Link>
-                  {` `}({formatTimeSpent(r.TimeAll)})
                 </ListCell>
+                <ListCell>
+                  <Time time={r.Time} />
+                </ListCell>
+                <ListCell>{r.CurrentStanding}</ListCell>
                 <ListCell>{driven2}</ListCell>
+                <ListCell>{r.KuskiCountAll}</ListCell>
+                <ListCell>{formatTimeSpent(r.TimeAll)}</ListCell>
+                <ListCell>{formatAttempts(r.AttemptsAll)}</ListCell>
               </ListRow>
             );
           })}
       </ListContainer>
-    </>
+    </Root>
   );
 };
+
+// for mobile
+const Root = styled.div`
+  overflow-x: scroll;
+`;
 
 export default RecentRecords;

--- a/src/pages/levels/RecordsCard.js
+++ b/src/pages/levels/RecordsCard.js
@@ -6,15 +6,22 @@ import RecentRecords from 'components/RecentRecords';
 import CardActions from '@material-ui/core/CardActions';
 import Button from 'components/Buttons';
 import { RecentBestRecords, useQueryAlt } from 'api';
+import Loading from 'components/Loading';
 
 const RecordsCard = () => {
   const [expanded, setExpanded] = useState(false);
 
-  const { data: records } = useQueryAlt(['RecentBestRecords', 7], async () =>
-    RecentBestRecords(7, 100),
+  // going too high on either (but I think especially days)
+  // can cause performance problems.
+  const days = 14;
+  const limit = 100;
+
+  const { data: records, isLoading } = useQueryAlt(
+    ['RecentBestRecords', days],
+    async () => RecentBestRecords(days, limit),
   );
 
-  const previewCount = 5;
+  const previewCount = limit;
 
   const show = records
     ? expanded
@@ -27,9 +34,22 @@ const RecordsCard = () => {
   return (
     <Card>
       <CardContent title="Records driven during battles are omitted.">
-        <Header h2>Records (Last 7 Days)</Header>
-        <div>Ordered by overall level playtime.</div>
+        <Header h2>
+          Top {limit} Non-Battle Records Driven in the Last {days} Days
+        </Header>
+        <div>
+          Ordered by the current overall playtime by all kuski's in the level.
+        </div>
+        <div>
+          Times shown were records when they were driven (and sometimes still
+          are).
+        </div>
+        <div>
+          Records driven on battle levels after the battle ends are shown.
+        </div>
+        <br />
         {records && <RecentRecords records={show} />}
+        {isLoading && <Loading />}
       </CardContent>
       {countMore > 0 && (
         <CardActions>

--- a/src/pages/levels/index.js
+++ b/src/pages/levels/index.js
@@ -13,6 +13,7 @@ import useElementSize from 'utils/useWindowSize';
 import LevelpacksDetailed from './LevelpacksDetailed';
 import Controls from './Controls';
 import FavStar from './FavStar';
+import RecordsCard from './RecordsCard';
 
 const getColumnCount = window_width => {
   if (window_width > 1300) {
@@ -105,6 +106,7 @@ const Levels = ({ tab, detailed }) => {
         >
           <Tab label="Packs" value="" />
           <Tab label="Collections" value="collections" />
+          <Tab label="Recent Records" value="recent-records" />
         </Tabs>
         {!tab && (
           <>
@@ -212,6 +214,11 @@ const Levels = ({ tab, detailed }) => {
             </FabCon>
           </>
         )}
+        {tab === 'recent-records' && (
+          <StyledRecentRecords>
+            <RecordsCard />
+          </StyledRecentRecords>
+        )}
       </Container>
     </Layout>
   );
@@ -254,6 +261,10 @@ const FabCon = styled.div`
 const Container = styled.div`
   padding-top: 10px;
   overflow: hidden;
+`;
+
+const StyledRecentRecords = styled.div`
+  padding: 10px 0 40px 0;
 `;
 
 export default Levels;

--- a/src/router.js
+++ b/src/router.js
@@ -86,6 +86,7 @@ const Routes = () => {
           {/* can't use levels/:tab due to conflict with levels/:LevelId above*/}
           <Levels path="levels/collections" tab="collections" />
           <Levels path="levels/detailed" tab="" detailed={1} />
+          <Levels path="levels/recent-records" tab="recent-records" />
           <LevelsAdd path="levels/add" />
           <LevelsAddCollection path="levels/collections/add" />
           <LevelpackCollection path="levels/collections/:name" />


### PR DESCRIPTION
The feature used to be on the homepage but then we scrapped it cuz it didn't really make too much sense. I added it back as a tab under levels this time (because I'm not sure where else really).

Since it's no longer a compact card, I added a few more columns.

Maybe we can test it out here and see how it goes. I thought maybe ordering by kuski's played instead of total playtime might be good. I think that might require a change to the back-end though. Maybe we can ask for some player feedback and then decide later.