### PR TITLE
feat(replay-comments): add pagination

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -89,7 +89,8 @@ export const useQueryAlt = (
 export const ReplayComment = replayIndex =>
   api.get(`replay_comment/${replayIndex}`);
 export const AddReplayComment = data => api.post(`replay_comment/add`, data);
-export const AllReplayComments = () => api.get('replay_comment/');
+export const AllReplayComments = (limit, offset) =>
+  api.get('replay_comment/', { limit, offset });
 export const ReplayRating = replayIndex =>
   api.get(`replay_rating/${replayIndex}`);
 export const AddReplayRating = data => api.post(`replay_rating/add`, data);

--- a/src/features/ReplayCommentArchive/index.js
+++ b/src/features/ReplayCommentArchive/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useStoreState, useStoreActions } from 'easy-peasy';
 import styled from 'styled-components';
 import Pagination from '@material-ui/lab/Pagination';
@@ -13,30 +13,26 @@ import Link from 'components/Link';
 import Kuski from 'components/Kuski';
 import Time from 'components/Time';
 import { useMediaQuery } from '@material-ui/core';
+import { useLocation, useNavigate } from '@reach/router';
+import queryString from 'query-string';
 
-const getShowing = (comments, page, pageSize) => {
-  const start = (+page - 1) * pageSize;
-  return comments.slice(start, start + pageSize);
-};
-
-const ReplayCommentArchive = props => {
-  const [page, setPage] = useState(1);
-
+const ReplayCommentArchive = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const query = queryString.parse(location.search);
+  const page = +query.page > 1 ? +query.page : 1;
   const pageSize = 20;
-
   const narrowCols = useMediaQuery('(max-width: 980px)');
-
   const { comments } = useStoreState(store => store.ReplayCommentArchive);
   const { fetchComments } = useStoreActions(
     store => store.ReplayCommentArchive,
   );
-
-  const showing = getShowing(comments, page, pageSize);
-  const pages = Math.ceil(comments.length / pageSize);
+  const [rows, countAll] = comments;
+  const pages = Math.ceil(countAll / pageSize);
 
   useEffect(() => {
-    fetchComments();
-  }, []);
+    fetchComments([pageSize, (page - 1) * pageSize]);
+  }, [page]);
 
   return (
     <Root>
@@ -45,7 +41,7 @@ const ReplayCommentArchive = props => {
           <ListCell width={narrowCols ? 250 : 400}>Replay</ListCell>
           <ListCell>Comment</ListCell>
         </ListHeader>
-        {showing.map((c, index) => {
+        {rows.map((c, index) => {
           const replay = c.Replay || {};
           const driver = replay.DrivenByData || replay.UploadedByData || {};
           const commenter = c.KuskiData || {};
@@ -91,7 +87,9 @@ const ReplayCommentArchive = props => {
       <Pag>
         <Pagination
           count={pages}
-          onChange={(event, value) => setPage(value)}
+          onChange={(event, value) =>
+            navigate(`/replays/comments/?page=${value}`)
+          }
           page={page}
           showFirstButton
           showLastButton

--- a/src/features/ReplayCommentArchive/store.js
+++ b/src/features/ReplayCommentArchive/store.js
@@ -1,15 +1,20 @@
-import { thunk } from 'easy-peasy';
-import { getSetter } from 'utils/easy-peasy';
+import { action, thunk } from 'easy-peasy';
 import { AllReplayComments } from '../../api';
 
 export default {
-  comments: [],
-  setComments: getSetter('comments'),
+  // rows, count
+  comments: [[], 0],
+  setComments: action((state, payload) => {
+    const [rows, count] = payload;
+    state.comments[0] = Array.isArray(rows) ? rows : [];
+    state.comments[1] = +(count || 0) || 0;
+  }),
   fetchComments: thunk(async (actions, payload, helpers) => {
-    const response = await AllReplayComments();
+    // passing limit, offset
+    const response = await AllReplayComments(payload[0], payload[1]);
 
     if (response.ok) {
-      actions.setComments(response.data);
+      actions.setComments([response.data.rows, response.data.count]);
     }
   }),
 };


### PR DESCRIPTION
Added pagination and added page number as url parameter.

Since we recently imported many thousands of replays and comments, there are now a lot and it makes the production site quite slow when it queries all at once. So now it just fetches one page at a time from the server.