### PR TITLE
fix(levels): Fix personal stats tab crashing with only spied runs

### DIFF
--- a/src/pages/level/StatsTable.jsx
+++ b/src/pages/level/StatsTable.jsx
@@ -39,17 +39,11 @@ const StatsTable = ({ data, loading }) => {
   };
 
   const lastPlayed = () => {
-    return maxBy(
-      data.filter(f => f.Finished !== 'S'),
-      'LastPlayed',
-    ).LastPlayed;
+    return maxBy(data, 'LastPlayed').LastPlayed;
   };
 
   const firstPlayed = () => {
-    return minBy(
-      data.filter(f => f.Finished !== 'S'),
-      'FirstPlayed',
-    ).FirstPlayed;
+    return minBy(data, 'FirstPlayed').FirstPlayed;
   };
 
   return (


### PR DESCRIPTION
First/last played dates will now include spied runs as well.