### PR TITLE
play stats tabs for level packs and cups

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -285,6 +285,12 @@ export const LevelPack = (LevelPackName, levels = 0) =>
   api.get(`levelpack/${LevelPackName}`, {
     levels: levels ? '1' : undefined,
   });
+export const LevelCollectionStats = (type, value) => {
+  if (type === 'ids') {
+    value = (value || []).join(',');
+  }
+  return api.get(`levelstats/collection/${type}/${value}`);
+};
 
 export const TotalTimes = data =>
   api.get(`levelpack/${data.levelPackIndex}/totaltimes/${data.eolOnly}`);

--- a/src/components/CupCurrent.jsx
+++ b/src/components/CupCurrent.jsx
@@ -12,7 +12,6 @@ const eventSort = (a, b) => a.CupIndex - b.CupIndex;
 
 const CupResults = props => {
   const { events, ShortName } = props;
-
   const currentEvents = events.filter(
     e =>
       e.EndTime > format(new Date(), 't') &&
@@ -25,6 +24,13 @@ const CupResults = props => {
       .findIndex(e => e.CupIndex === event.CupIndex);
     return index + 1;
   };
+
+  const pastEvents = events.sort(eventSort).filter(
+    e => e.EndTime < format(new Date(), 't')
+  );
+
+  const lastEvent = pastEvents[pastEvents.length - 1];
+  const lastEventNumber = lastEvent && getEventNumber(lastEvent);
 
   return (
     <Container>
@@ -80,11 +86,21 @@ const CupResults = props => {
           </Paper>
         );
       })}
+      {lastEvent && (
+        <LastResultsLink>
+            <Link to={`/cup/${ShortName}/events/${lastEventNumber}/results`}>Event {lastEventNumber} Results/Replays</Link>
+        </LastResultsLink>
+      )}
     </Container>
   );
 };
 
 const Container = styled.div``;
+
+const LastResultsLink = styled.div`
+  padding: 5px 0 8px 0;
+  text-align: center;
+`;
 
 const EventHeader = styled.div`
   text-align: center;

--- a/src/components/Popularity.jsx
+++ b/src/components/Popularity.jsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 const Popularity = ({ before, after, ...props }) => {
   const pct = Number(props.widthPct || 0).toFixed(2);
@@ -28,9 +28,23 @@ const After = styled.div``;
 
 const Root = styled.div`
   .pop-wrapper {
+    position: relative;
     display: flex;
     align-items: center;
     justify-content: flex-start;
+    ${p => p.bordered && css`
+      &::after {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: ${p => p.theme.linkColor};
+        opacity: 0.1;
+      }
+    `}
     &:hover {
       ${BarWrapper} {
         background: ${p => p.pageBackgroundDark};

--- a/src/components/Preview.jsx
+++ b/src/components/Preview.jsx
@@ -123,6 +123,9 @@ const Close = styled(CloseIcon)`
 const Next = styled(NavigateNextIcon)`
   cursor: pointer;
   color: ${p => p.theme.lightTextColor};
+  // make larger (good for mobile especially)
+  font-size: 34px !important;
+  margin-top: -3px;
 
   :hover {
     color: blue;
@@ -132,6 +135,9 @@ const Next = styled(NavigateNextIcon)`
 const Previous = styled(NavigateBeforeIcon)`
   cursor: pointer;
   color: ${p => p.theme.lightTextColor};
+  // make larger (good for mobile especially)
+  font-size: 34px !important;
+  margin-top: -3px;
 
   :hover {
     color: blue;

--- a/src/easypeasy.js
+++ b/src/easypeasy.js
@@ -41,8 +41,10 @@ import Notifications from 'features/Notifications/store';
 import ReplayCommentArchive from 'features/ReplayCommentArchive/store';
 import Recap from 'pages/recap/store';
 import DatInfo from 'pages/datinfo/store';
+import LevelCollectionStats from 'features/LevelCollectionStats/store';
 
 export default {
+  LevelCollectionStats,
   ReplayCommentArchive,
   ReplayComments,
   ReplayRating,

--- a/src/features/LevelCollectionStats/index.jsx
+++ b/src/features/LevelCollectionStats/index.jsx
@@ -1,0 +1,126 @@
+import React, { useEffect } from 'react';
+import { useStoreState, useStoreActions } from 'easy-peasy';
+import styled from 'styled-components';
+import Popularity from 'components/Popularity';
+import {
+  ListContainer,
+  ListCell,
+  ListHeader,
+  ListRow,
+} from '../../components/List';
+import Link from 'components/Link';
+import { keyBy, mapValues, maxBy } from 'lodash';
+import { formatTimeSpent, formatPct, formatAttempts } from 'utils/format';
+import { shiftedLogisticWithIntersects } from 'utils/calcs';
+
+const LevelCollectionStats = ({ levelIds }) => {
+  const { stats } = useStoreState(store => store.LevelCollectionStats);
+  const { fetchStats } = useStoreActions(
+    store => store.LevelCollectionStats,
+  );
+  let indexedStats = keyBy(stats, 'LevelIndex');
+  const type = 'ids';
+
+  const levelStatsForEachLevel = stats.map(s => s?.LevelStatsData || {});
+
+  const maxes = mapValues(stats?.[0]?.LevelStatsData || {}, (value, key) => {
+    const rowWithMax = maxBy(levelStatsForEachLevel, key);
+    return rowWithMax?.[key];
+  })
+
+  const perMinute = (count, seconds) => {
+    const per = seconds > 0 ? (count / (seconds / 6000)) : 0;
+    return per.toFixed(2);
+  };
+
+  useEffect(() => {
+    fetchStats(['ids', levelIds]);
+  }, [type, levelIds.join(',')]);
+
+  return (
+    <Root>
+      <TableWrapper>
+        <StyledListContainer>
+          <ListHeader>
+            <ListCell>Filename</ListCell>
+            <ListCell>Level Name</ListCell>
+            <ListCell>Playtime</ListCell>
+            <ListCell>Kuski's Played</ListCell>
+            <ListCell>Kuski Finish %</ListCell>
+            <ListCell>Finish %</ListCell>
+            <ListCell>Death %</ListCell>
+            <ListCell title="Average left volts per minute on finished runs">Left Volt /min</ListCell>
+            <ListCell title="Average right volts per minute on finished runs">Right Volt /min</ListCell>
+            <ListCell title="Average alot volts per minute on finished runs">Alo Volt /min</ListCell>
+            <ListCell title="Average turns per minute on finished runs">Turns /min</ListCell>
+          </ListHeader>
+
+          {levelIds.map((LevelIndex, index) => {
+
+            const level = indexedStats?.[LevelIndex] || [];
+            const levelStats = level?.LevelStatsData;
+            const timePlayed = formatTimeSpent(levelStats?.TimeAll)
+            const kuskisPlayed = formatAttempts(levelStats?.KuskiCountAll)
+            const kuskiFinishPct = formatPct(levelStats?.KuskiCountF, levelStats?.KuskiCountAll)
+            const finishPct = formatPct(levelStats?.AttemptsF, levelStats?.AttemptsAll)
+            const deathPct = formatPct(levelStats?.AttemptsD, levelStats?.AttemptsAll)
+            const leftVoltsPerMin = perMinute(levelStats?.LeftVoltF, levelStats?.TimeF)
+            const rightVoltsPerMin = perMinute(levelStats?.RightVoltF, levelStats?.TimeF)
+            const aloVoltsPerMin = perMinute(levelStats?.SuperVoltF, levelStats?.TimeF)
+            const turnsPerMin = perMinute(levelStats?.TurnF, levelStats?.TimeF)
+
+            return (
+              <ListRow key={index}>
+                <ListCell>
+                  <Link to={`/levels/${level.LevelIndex}`}>{level.LevelName}</Link>
+                </ListCell>
+                <ListCell>{level.LongName}</ListCell>
+                <ListCell>{timePlayed} <br />
+                  <Popularity bordered={true} widthPct={formatPct(levelStats?.TimeAll, maxes?.TimeAll)} />
+                </ListCell>
+                <ListCell>{kuskisPlayed} <br />
+                  <Popularity bordered={true} widthPct={formatPct(levelStats?.KuskiCountAll, maxes?.KuskiCountAll)} />
+                </ListCell>
+                <ListCell>{kuskiFinishPct}% <br />
+                  <Popularity bordered={true} widthPct={kuskiFinishPct} />
+                </ListCell>
+                <ListCell>{finishPct}% <br />
+                  <Popularity bordered={true} widthPct={finishPct} />
+                </ListCell>
+                <ListCell>{deathPct}% <br />
+                  <Popularity bordered={true} widthPct={deathPct} />
+                </ListCell>
+                <ListCell>{leftVoltsPerMin} &lt;-<br />
+                  <Popularity bordered={true} widthPct={100 * shiftedLogisticWithIntersects([14, 0.25], [25, 0.65], leftVoltsPerMin)} />
+                </ListCell>
+                <ListCell>{rightVoltsPerMin} -&gt;<br />
+                  <Popularity bordered={true} widthPct={100 * shiftedLogisticWithIntersects([14, 0.25], [25, 0.65], rightVoltsPerMin)} />
+                </ListCell>
+                <ListCell>{aloVoltsPerMin} --&gt;<br />
+                  <Popularity bordered={true} widthPct={100 * shiftedLogisticWithIntersects([14, 0.25], [25, 0.65], aloVoltsPerMin)} />
+                </ListCell>
+                <ListCell>{turnsPerMin} t<br />
+                  <Popularity bordered={true} widthPct={100 * shiftedLogisticWithIntersects([14, 0.25], [25, 0.65], turnsPerMin)} />
+                </ListCell>
+              </ListRow>
+            );
+          })}
+        </StyledListContainer>
+      </TableWrapper>
+    </Root>
+  );
+};
+
+const Root = styled.div`
+  background: ${p => p.theme.paperBackground};
+`;
+
+const TableWrapper = styled.div`
+  overflow-x: scroll;
+`
+
+const StyledListContainer = styled(ListContainer)`
+  min-width: 980px;
+`
+
+export default LevelCollectionStats;

--- a/src/features/LevelCollectionStats/store.js
+++ b/src/features/LevelCollectionStats/store.js
@@ -1,0 +1,24 @@
+import { action, thunk } from 'easy-peasy';
+import { LevelCollectionStats } from '../../api';
+
+export default {
+  // rows, count
+  stats: [],
+  setStats: action((state, payload) => {
+    state.stats = payload;
+  }),
+  fetchStats: thunk(async (actions, payload, helpers) => {
+    actions.setStats([]);
+    const response = await LevelCollectionStats(payload[0], payload[1]);
+
+    if (response.ok) {
+      const stats = response?.data?.stats;
+      if (!stats) {
+        console.error('Error', response);
+        actions.setStats([]);
+      } else {
+        actions.setStats(stats);
+      }
+    }
+  }),
+};

--- a/src/features/RankingTable/index.jsx
+++ b/src/features/RankingTable/index.jsx
@@ -63,75 +63,85 @@ const RankingTable = ({
   }
 
   return (
-    <>
-      {FilteredRanking && (
-        <>
-          <SortableList
-            headers={[
-              { name: '#', sort: false, width: 40 },
-              { name: 'Player', sort: false, width: 0, minWidth: 110 },
-              { name: 'Ranking', sort: true, width: 76, right: 1 },
-              { name: 'Points', sort: true, width: 76, right: 1 },
-              { name: 'Wins', sort: true, width: 76, right: 1 },
-              { name: 'Win %', sort: false, width: 76, right: 1 },
-              { name: 'Designed', sort: true, width: 76, right: 1 },
-              { name: 'Played', sort: true, width: 93, right: 1 },
-            ]}
-            sort={s => {
-              setSortOrder(s.sort);
-              setSort(`${s.header}${battleType}`);
-            }}
-            defaultSort="Ranking"
-          />
-          <ListContainer flex>
-            <List
-              height={listHeight}
-              itemCount={FilteredRanking.length}
-              itemSize={40}
-            >
-              {({ index, style }) => {
-                const i = FilteredRanking[index];
-                return (
-                  <div style={style} key={i[tableIndex]}>
-                    <ListRow>
-                      <ListCell width={40}>{index + 1}.</ListCell>
-                      <ListCell minWidth={110}>
-                        <Kuski kuskiData={i.KuskiData} team flag />
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {parseFloat(i[Ranking]).toFixed(2)}
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {i[Points]}
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {i[Wins]}
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {i[Played5] === 0
-                          ? 'N/A'
-                          : parseFloat((i[Wins] * 100) / i[Played5]).toFixed(2)}
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {i[Designed]}
-                      </ListCell>
-                      <ListCell right width={76}>
-                        {i[Played]}
-                      </ListCell>
-                    </ListRow>
-                  </div>
-                );
+    <Root>
+      <Inner>
+        {FilteredRanking && (
+          <>
+            <SortableList
+              headers={[
+                { name: '#', sort: false, width: 12 },
+                { name: 'Player', sort: false, width: 0, minWidth: 130 },
+                { name: 'Ranking', sort: true, width: 48, right: 1 },
+                { name: 'Points', sort: true, width: 48, right: 1 },
+                { name: 'Wins', sort: true, width: 48, right: 1 },
+                { name: 'Win %', sort: false, width: 48, right: 1 },
+                { name: 'Designed', sort: true, width: 65, right: 1 },
+                { name: 'Played', sort: true, width: 48, right: 1 },
+              ]}
+              sort={s => {
+                setSortOrder(s.sort);
+                setSort(`${s.header}${battleType}`);
               }}
-            </List>
-            {fixedHeight ? null : (
-              <Amount>Players: {FilteredRanking.length}</Amount>
-            )}
-          </ListContainer>
-        </>
-      )}
-    </>
+              defaultSort="Ranking"
+            />
+            <ListContainer flex>
+              <List
+                height={listHeight}
+                itemCount={FilteredRanking.length}
+                itemSize={40}
+              >
+                {({ index, style }) => {
+                  const i = FilteredRanking[index];
+                  return (
+                    <div style={style} key={i[tableIndex]}>
+                      <ListRow>
+                        <ListCell width={12}>{index + 1}.</ListCell>
+                        <ListCell minWidth={130}>
+                          <Kuski kuskiData={i.KuskiData} team flag />
+                        </ListCell>
+                        <ListCell right width={48}>
+                          {parseFloat(i[Ranking]).toFixed(2)}
+                        </ListCell>
+                        <ListCell right width={48}>
+                          {i[Points]}
+                        </ListCell>
+                        <ListCell right width={48}>
+                          {i[Wins]}
+                        </ListCell>
+                        <ListCell right width={48}>
+                          {i[Played5] === 0
+                            ? 'N/A'
+                            : parseFloat((i[Wins] * 100) / i[Played5]).toFixed(2)}
+                        </ListCell>
+                        <ListCell right width={65}>
+                          {i[Designed]}
+                        </ListCell>
+                        <ListCell right width={48}>
+                          {i[Played]}
+                        </ListCell>
+                      </ListRow>
+                    </div>
+                  );
+                }}
+              </List>
+              {fixedHeight ? null : (
+                <Amount>Players: {FilteredRanking.length}</Amount>
+              )}
+            </ListContainer>
+          </>
+        )}
+      </Inner>
+    </Root>
   );
 };
+
+const Root = styled.div`
+  overflow-x: auto;
+`
+
+const Inner = styled.div`
+  min-width: 630px;
+`
 
 const Amount = styled.div`
   padding: ${p => p.theme.padSmall};

--- a/src/features/ReplayList/index.jsx
+++ b/src/features/ReplayList/index.jsx
@@ -102,14 +102,14 @@ export default function ReplayList({
     if (!previewRec) {
       return null;
     }
-    const currentIndex = findIndex(replays.rows, {
+    const currentIndex = findIndex(replays, {
       ReplayIndex: previewRec.ReplayIndex,
     });
 
     const nextIndex =
-      currentIndex + 1 >= replays.rows.length ? currentIndex : currentIndex + 1;
+      currentIndex + 1 >= replays.length ? currentIndex : currentIndex + 1;
 
-    const nextReplay = replays.rows[nextIndex];
+    const nextReplay = replays[nextIndex];
     setPreviewRec(nextReplay);
   };
 
@@ -117,14 +117,14 @@ export default function ReplayList({
     if (!previewRec) {
       return null;
     }
-    const currentIndex = findIndex(replays.rows, {
+    const currentIndex = findIndex(replays, {
       ReplayIndex: previewRec.ReplayIndex,
     });
 
     const previousIndex =
       currentIndex - 1 < 0 ? currentIndex : currentIndex - 1;
 
-    const previousReplay = replays.rows[previousIndex];
+    const previousReplay = replays[previousIndex];
     setPreviewRec(previousReplay);
   };
 
@@ -283,7 +283,7 @@ export default function ReplayList({
       {!summary && (
         <Box p={2}>
           <TablePagination
-            style={{ width: '600px' }}
+            style={{ width: '600px; max-width: 100%;' }}
             component="div"
             count={-1}
             rowsPerPage={25}

--- a/src/pages/cup/PlayStats.jsx
+++ b/src/pages/cup/PlayStats.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from 'styled-components';
+import LevelCollectionStats from 'features/LevelCollectionStats';
+
+const PlayStats = ({ events }) => {
+  const levelIds = events?.map(event => event.LevelIndex);
+
+  return (
+    <Root>
+      <LevelCollectionStats
+        levelIds={levelIds}
+      />
+    </Root>
+  );
+};
+
+const Root = styled.div`
+  padding-bottom: 50px;
+`;
+
+export default PlayStats;

--- a/src/pages/cup/index.jsx
+++ b/src/pages/cup/index.jsx
@@ -16,6 +16,7 @@ import Admin from './Admin';
 import Dashboard from './Dashboard';
 import Personal from './Personal';
 import Team from './Team';
+import PlayStats from './PlayStats';
 
 const Cups = props => {
   const { ShortName } = props;
@@ -68,6 +69,7 @@ const Cups = props => {
             <Tab label="Events" value="events" />
             <Tab label="Standings" value="standings" />
             <Tab label="Rules & Info" value="rules" />
+            <Tab label="Play Stats" value="play-stats" />
             <Tab label="Blog" value="blog" />
             {nickId() > 0 && <Tab label="Personal" value="personal" />}
             {nickId() > 0 && <Tab label="Team" value="team" />}
@@ -118,6 +120,7 @@ const Cups = props => {
             <Personal path="personal" />
             <Team path="team" />
             {isCupAdmin && <Admin path="admin" />}
+            <PlayStats path="play-stats" cup={cup} events={events} />
           </Router>
         </>
       )}

--- a/src/pages/level/index.jsx
+++ b/src/pages/level/index.jsx
@@ -572,6 +572,8 @@ const Level = ({ LevelId }) => {
 };
 
 const AccordionReplays = styled(AccordionDetails)`
+  max-height: 400px;
+  overflow-y: auto;
   & {
     flex-direction: column;
   }

--- a/src/pages/levelpack/PlayStats.jsx
+++ b/src/pages/levelpack/PlayStats.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+import LevelCollectionStats from 'features/LevelCollectionStats';
+
+const PlayStats = ({ LevelPack }) => {
+  const levels = LevelPack?.levels || [];
+  const levelIds = levels.map(l => l.LevelIndex);
+
+  return (
+    <Root>
+      <LevelCollectionStats
+        levelIds={levelIds}
+      />
+    </Root>
+  );
+};
+
+const Root = styled.div`
+  padding-bottom: 50px;
+`;
+
+export default PlayStats;

--- a/src/pages/levelpack/index.jsx
+++ b/src/pages/levelpack/index.jsx
@@ -22,6 +22,7 @@ import Admin from './Admin';
 import { useQueryAlt, LevelPackLevelStats } from '../../api';
 import Menus from './Menus';
 import RecordHistory from './RecordHistory';
+import PlayStats from './PlayStats';
 
 const LevelPack = ({ name, tab, ...props }) => {
   const isRehydrated = useStoreRehydrated();
@@ -110,10 +111,11 @@ const LevelPack = ({ name, tab, ...props }) => {
           <Tab label="Records" value="" />
           <Tab label="Total Times" value="total-times" />
           <Tab label="King list" value="king-list" />
-          <Tab label="Record History" value="record-history" />
           <Tab label="Personal" value="personal" />
           <Tab label="Multi records" value="multi" />
           <Tab label="Replays" value="replays" />
+          <Tab label="Play Stats" value="play-stats" />
+          <Tab label="Record History" value="record-history" />
           <Tab label="Crippled" value="crippled" />
           {adminAuth && <Tab label="Admin" value="admin" />}
         </Tabs>
@@ -176,6 +178,11 @@ const LevelPack = ({ name, tab, ...props }) => {
             persist={`levelpack-${levelPackInfo.LevelPackIndex}`}
             nonsticky
             levelPack={levelPackInfo.LevelPackIndex}
+          />
+        )}
+        {tab === 'play-stats' && (
+          <PlayStats
+            LevelPack={levelPackInfo}
           />
         )}
         {tab === 'admin' && adminAuth && <Admin />}

--- a/src/utils/calcs.js
+++ b/src/utils/calcs.js
@@ -24,6 +24,29 @@ export const shiftedLogisticFn = (b, x) => {
   return 2 / (1 + Math.pow(b, x)) - 1;
 };
 
+/**
+ * Ie. a shifted logistic function that intersects two points
+ *
+ * If you want a value of 50 to map to 0.2, and a value of 400 to map to 0.8,
+ * then use: shiftedLogisticWithIntersects([50, 0.2], [400, 0.8], value),
+ * so if value is 400, you would expect 0.8 as the return value.
+ *
+ * it seems to work.. Ty chatGPT.
+ */
+export const shiftedLogisticWithIntersects = (
+  [x1, y1],
+  [x2, y2],
+  value,
+  decimals = 5,
+) => {
+  const logit1 = Math.log(y1 / (1 - y1));
+  const logit2 = Math.log(y2 / (1 - y2));
+  const k = (logit2 - logit1) / (x2 - x1);
+  const x0 = (x1 * logit2 - x2 * logit1) / (logit2 - logit1);
+  const result = 1 / (1 + Math.exp(-k * (value - x0)));
+  return Number(result.toFixed(decimals));
+};
+
 // https://stackoverflow.com/questions/5259421/cumulative-distribution-function-in-javascript
 // normal cumulative distribution function
 // maps a value from 0 to infinity to 0 to 1

--- a/src/utils/format.js
+++ b/src/utils/format.js
@@ -11,7 +11,10 @@ export const formatTimeSpent = time => {
 
 // for levelstats, likely large number of attempts.
 export const formatAttempts = num => {
-  return Number(num).toLocaleString();
+  if (num && num > 0) {
+    return Number(num).toLocaleString();
+  }
+  return 0;
 };
 
 export const formatPct = (num, div, precision = 2) => {


### PR DESCRIPTION
Adds 2 new pages...

Level pack play stats, and Cup play stats.

I didn't put too much thought into the stats or how they are displayed for now (just lots of "popularity" bars). But we could modify some things later.

![image](https://github.com/user-attachments/assets/3cbf7364-79c6-4c7c-bc0b-ce781677456b)

![image](https://github.com/user-attachments/assets/5f06a0f0-5937-4796-8325-d5a8f13da22a)
