### PR TITLE
fix(levels): show correct number of levels in search pagination

### DIFF
--- a/src/features/LevelList/index.jsx
+++ b/src/features/LevelList/index.jsx
@@ -322,7 +322,11 @@ export default function LevelList({
             <SortPagination>
               <TablePagination
                 component="div"
-                count={-1}
+                count={
+                  levels.rows.length < pageSize
+                    ? pageSize * page + levels.rows.length
+                    : -1
+                }
                 rowsPerPageOptions={false}
                 rowsPerPage={pageSize}
                 page={page}


### PR DESCRIPTION
If result has less levels than `pageSize`, show number of levels in pagination (next page button will be disabled automatically).