### PR TITLE
fix(levpacks): fix highlight timeframe changing

### DIFF
--- a/src/pages/levelpack/Menus.jsx
+++ b/src/pages/levelpack/Menus.jsx
@@ -176,7 +176,9 @@ const Menus = ({ name, hideFilter }) => {
                       <RadioGroup
                         aria-label="highlightWeeks"
                         value={highlightWeeks}
-                        onChange={n => setHighlightWeeks(n.target.value)}
+                        onChange={n =>
+                          setHighlightWeeks(Number(n.target.value))
+                        }
                         name="weeks"
                         row
                       >


### PR DESCRIPTION
Fixes https://github.com/elmadev/elmaonline-site/issues/778.

Previously, when changing to a different radio button, the result was saved as a string, that's why the selection wasn't working. The actual highlight was still working as stuff like `highlight[highlightWeeks]` works fine even with strings.

Also apparently the "checked" property is redundant for each FormControlLabel as RadioGroup does the selection itself, however I kept it as it is as it's working properly now.

Tested the changes locally (with custom mock values for times driven in 1-4 weeks) and it's working properly:

<img width="1365" height="1104" alt="highlight-fix" src="https://github.com/user-attachments/assets/a209b481-fd0c-4f83-9b1a-a231c54f9f0b" />

The value also persists after page refresh, the same way other settings do.