### PR TITLE
fix(replays): fix replay unmerging

### DIFF
--- a/src/components/RecListItem.jsx
+++ b/src/components/RecListItem.jsx
@@ -27,7 +27,9 @@ const RecListItem = ({
   const updateUrl = (unmerge = false) => {
     if (unmerge) {
       return merge?.includes(';')
-        ? `${location.pathname}?merge=${merge.replace(`;${replay.UUID}`, '')}`
+        ? merge.startsWith(`${replay.UUID};`)
+          ? `${location.pathname}?merge=${merge.replace(`${replay.UUID};`, '')}`
+          : `${location.pathname}?merge=${merge.replace(`;${replay.UUID}`, '')}`
         : location.pathname;
     }
     return merge

--- a/src/pages/replay/index.jsx
+++ b/src/pages/replay/index.jsx
@@ -159,7 +159,9 @@ const Replay = () => {
   const updateUrl = (unmerge = false, recUuid) => {
     if (unmerge) {
       return merge?.includes(';')
-        ? `${location.pathname}?merge=${merge.replace(`;${recUuid}`, '')}`
+        ? merge.startsWith(`${recUuid};`)
+          ? `${location.pathname}?merge=${merge.replace(`${recUuid};`, '')}`
+          : `${location.pathname}?merge=${merge.replace(`;${recUuid}`, '')}`
         : location.pathname;
     }
     return merge


### PR DESCRIPTION
Fixes https://github.com/elmadev/elmaonline-site/issues/780.

After merging replays, the second replay (aka the first additional replay) doesn't have a semicolon before its uuid, so the unmerging logic could never found the relevant part of the string to remove if you merged more than 2 replays. I have added the missing condition so now this case is covered as well.

Verified the changes locally. Separately for regular replays (RecListItem.jsx) and cup replays (index.jsx).